### PR TITLE
fix(auth): resolve token expiration hangs and redirect issues (#29)

### DIFF
--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/NotificationSettingsController.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/NotificationSettingsController.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,7 +42,7 @@ public class NotificationSettingsController {
         log.info("Request: GET /notifications/settings");
         Long userId = JwtPrincipalUtil.getCurrentUserId();
         if (userId == null) {
-            throw new IllegalArgumentException("Отсутствует аутентификация");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Отсутствует аутентификация");
         }
         NotificationSettingsService.SettingsSnapshot snapshot = settingsService.getSettingsSnapshot(userId);
 
@@ -68,7 +69,7 @@ public class NotificationSettingsController {
                 payload.unitId(), payload.techEnabled(), payload.masterEnabled());
         Long userId = JwtPrincipalUtil.getCurrentUserId();
         if (userId == null) {
-            throw new IllegalArgumentException("Отсутствует аутентификация");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Отсутствует аутентификация");
         }
         Long unitId = parseLong(payload.unitId(), "unitId");
 

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/UserProfileController.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/UserProfileController.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,7 +40,7 @@ public class UserProfileController {
         log.info("Request: GET /users/me");
         Long userId = JwtPrincipalUtil.getCurrentUserId();
         if (userId == null) {
-            throw new IllegalArgumentException("Отсутствует аутентификация");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Отсутствует аутентификация");
         }
         UserProfileService.ProfileSnapshot snapshot = profileService.getProfileSnapshot(userId);
 

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/config/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/config/CustomAccessDeniedHandler.java
@@ -1,0 +1,46 @@
+package dev.savushkin.scada.mobile.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.savushkin.scada.mobile.backend.api.dto.AuthErrorResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Custom {@link AccessDeniedHandler} для возврата консистентного
+ * {@link AuthErrorResponseDTO} при 403 (Forbidden) от Spring Security.
+ */
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public CustomAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull AccessDeniedException accessDeniedException
+    ) throws IOException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        AuthErrorResponseDTO error = AuthErrorResponseDTO.error(
+                "Доступ запрещён. Недостаточно прав для выполнения операции."
+        );
+
+        objectMapper.writeValue(response.getWriter(), error);
+    }
+}

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/config/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,49 @@
+package dev.savushkin.scada.mobile.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.savushkin.scada.mobile.backend.api.dto.AuthErrorResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Custom {@link AuthenticationEntryPoint} для возврата консистентного
+ * {@link AuthErrorResponseDTO} при 401 (Unauthorized) от Spring Security.
+ * <p>
+ * Заменяет дефолтный {@code BearerTokenAuthenticationEntryPoint}, который возвращает
+ * неструктурированный JSON вроде {@code {"error":"invalid_token"}}.
+ */
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public CustomAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull AuthenticationException authException
+    ) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        AuthErrorResponseDTO error = AuthErrorResponseDTO.error(
+                "Сессия истекла или недействительна. Войдите заново."
+        );
+
+        objectMapper.writeValue(response.getWriter(), error);
+    }
+}

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package dev.savushkin.scada.mobile.backend.config;
 import dev.savushkin.scada.mobile.backend.config.jwt.AudienceValidator;
 import dev.savushkin.scada.mobile.backend.config.jwt.JwtProperties;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.jspecify.annotations.NonNull;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -54,9 +56,15 @@ public class SecurityConfig {
     private static final String JWT_AUDIENCE = "scada-mobile-api";
 
     private final JwtProperties jwtProperties;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+    private final AccessDeniedHandler accessDeniedHandler;
 
-    public SecurityConfig(JwtProperties jwtProperties) {
+    public SecurityConfig(JwtProperties jwtProperties,
+                          AuthenticationEntryPoint authenticationEntryPoint,
+                          AccessDeniedHandler accessDeniedHandler) {
         this.jwtProperties = jwtProperties;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
     }
 
     @Bean
@@ -93,6 +101,8 @@ public class SecurityConfig {
                     .decoder(jwtDecoder(jwtProperties))
                     .jwtAuthenticationConverter(jwtAuthenticationConverter())
                 )
+                .authenticationEntryPoint(authenticationEntryPoint)
+                .accessDeniedHandler(accessDeniedHandler)
             );
 
         return http.build();

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/services/AuthService.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/services/AuthService.java
@@ -3,6 +3,7 @@ package dev.savushkin.scada.mobile.backend.services;
 import dev.savushkin.scada.mobile.backend.application.ports.RefreshTokenRepository;
 import dev.savushkin.scada.mobile.backend.application.ports.UserAuthRepository;
 import dev.savushkin.scada.mobile.backend.application.ports.UserAuthRepository.AuthUserWithPassword;
+import dev.savushkin.scada.mobile.backend.config.jwt.JwtProperties;
 import dev.savushkin.scada.mobile.backend.config.jwt.JwtTokenProvider;
 import dev.savushkin.scada.mobile.backend.domain.model.AuthUser;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.RefreshTokenEntity;
@@ -23,17 +24,20 @@ public class AuthService {
     private final UserJpaRepository userJpaRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
     private final PasswordEncoder passwordEncoder;
 
     public AuthService(UserAuthRepository userAuthRepository,
                        UserJpaRepository userJpaRepository,
                        RefreshTokenRepository refreshTokenRepository,
                        JwtTokenProvider jwtTokenProvider,
+                       JwtProperties jwtProperties,
                        PasswordEncoder passwordEncoder) {
         this.userAuthRepository = userAuthRepository;
         this.userJpaRepository = userJpaRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.jwtProperties = jwtProperties;
         this.passwordEncoder = passwordEncoder;
     }
 
@@ -81,7 +85,7 @@ public class AuthService {
         entity.setUser(userEntity);
         entity.setTokenHash(refreshHash);
         entity.setCreatedAt(Instant.now());
-        entity.setExpiresAt(Instant.now().plus(7, ChronoUnit.DAYS));
+        entity.setExpiresAt(Instant.now().plus(jwtProperties.getRefreshExpirationDays(), ChronoUnit.DAYS));
         entity.setRevoked(false);
         refreshTokenRepository.save(entity);
 
@@ -119,7 +123,7 @@ public class AuthService {
         newEntity.setUser(user);
         newEntity.setTokenHash(newRefreshHash);
         newEntity.setCreatedAt(Instant.now());
-        newEntity.setExpiresAt(Instant.now().plus(7, ChronoUnit.DAYS));
+        newEntity.setExpiresAt(Instant.now().plus(jwtProperties.getRefreshExpirationDays(), ChronoUnit.DAYS));
         newEntity.setRevoked(false);
         refreshTokenRepository.save(newEntity);
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -63,7 +63,7 @@ cors:
 jwt:
   access-secret: "${SCADA_MOBILE_JWT_ACCESS_SECRET:}"
   refresh-secret: "${SCADA_MOBILE_JWT_REFRESH_SECRET:}"
-  access-expiration-minutes: 15
+  access-expiration-minutes: 1440
   refresh-expiration-days: 7
 
 # Логирование — конфигурация в src/main/resources/logback-spring.xml

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,7 @@
 import { HTTP_REQUEST } from '../config';
 import { getAccessToken, clearAllAuthData } from '../auth/session';
 import { refreshAccessToken } from './auth';
+import { AuthSessionExpiredError } from '../errors/AppError';
 
 let isRefreshing = false;
 let refreshSubscribers: Array<(token: string | null) => void> = [];
@@ -30,7 +31,7 @@ function logRequest(method: string, url: string, status?: number): void {
  * Централизованный fetch с автоматическим:
  * - Добавлением Authorization: Bearer <accessToken>
  * - Обработкой 401 → попытка refresh → retry запроса
- * - Если refresh не удался — возвращает 401 вызывающему
+ * - Если refresh не удался — выбрасывает AuthSessionExpiredError
  */
 export async function apiFetch(url: string, options: RequestInit = {}): Promise<Response> {
   const token = getAccessToken();
@@ -60,10 +61,10 @@ export async function apiFetch(url: string, options: RequestInit = {}): Promise<
   // 401 — пробуем refresh
   if (isRefreshing) {
     // Ждём завершения текущего refresh
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       subscribeToRefresh((newToken) => {
         if (!newToken) {
-          resolve(resp);
+          reject(new AuthSessionExpiredError());
           return;
         }
         const retryHeaders = new Headers(options.headers);
@@ -80,10 +81,9 @@ export async function apiFetch(url: string, options: RequestInit = {}): Promise<
 
   if (!newToken) {
     // Refresh не удался — токены протухли или инвалидированы.
-    // Очищаем auth-данные и редиректим на логин.
+    // Очищаем auth-данные и сигнализируем об истечении сессии.
     clearAllAuthData();
-    window.location.href = '/login';
-    return resp;
+    throw new AuthSessionExpiredError();
   }
 
   // Retry с новым токеном

--- a/frontend/src/auth/RequireAdmin.tsx
+++ b/frontend/src/auth/RequireAdmin.tsx
@@ -1,8 +1,22 @@
 import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
+/**
+ * Route guard: защищает админ-маршруты, требуя аутентификации и роли ADMIN.
+ *
+ * Пока идёт начальная проверка токена (isVerifying) — показывает минимальный
+ * загрузчик, чтобы избежать "authenticated flash" при старте с expired token.
+ */
 export function RequireAdmin() {
-  const { isAuthenticated, isAdmin } = useAuth();
+  const { isAuthenticated, isAdmin, isVerifying } = useAuth();
+
+  if (isVerifying) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-[#e7e8ea] border-t-[#1A1C1E]" />
+      </div>
+    );
+  }
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;

--- a/frontend/src/auth/RequireAuth.tsx
+++ b/frontend/src/auth/RequireAuth.tsx
@@ -1,9 +1,23 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
+/**
+ * Route guard: защищает вложенные маршруты, требуя аутентификации.
+ *
+ * Пока идёт начальная проверка токена (isVerifying) — показывает минимальный
+ * загрузчик, чтобы избежать "authenticated flash" при старте с expired token.
+ */
 export function RequireAuth() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isVerifying } = useAuth();
   const location = useLocation();
+
+  if (isVerifying) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-[#e7e8ea] border-t-[#1A1C1E]" />
+      </div>
+    );
+  }
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from: location }} />;

--- a/frontend/src/auth/session.ts
+++ b/frontend/src/auth/session.ts
@@ -3,6 +3,9 @@ const ROLE_STORAGE_KEY = 'scada.role';
 const ACCESS_TOKEN_KEY = 'scada.accessToken';
 const REFRESH_TOKEN_KEY = 'scada.refreshToken';
 
+/** Канал для синхронизации auth-состояния между вкладками. */
+const AUTH_BROADCAST_CHANNEL = 'scada-auth-sync';
+
 function normalizeUserId(value: string): string {
   return value.trim();
 }
@@ -66,6 +69,7 @@ export function setTokens(accessToken: string, refreshToken: string): void {
   try {
     localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
     localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+    broadcastAuthEvent({ type: 'tokens-updated' });
   } catch {
     // ignore storage failures
   }
@@ -74,6 +78,7 @@ export function setTokens(accessToken: string, refreshToken: string): void {
 export function setAccessToken(accessToken: string): void {
   try {
     localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+    broadcastAuthEvent({ type: 'tokens-updated' });
   } catch {
     // ignore storage failures
   }
@@ -114,7 +119,80 @@ export function clearAllAuthData(): void {
     localStorage.removeItem('scada.assignedUnits');
     localStorage.removeItem(ACCESS_TOKEN_KEY);
     localStorage.removeItem(REFRESH_TOKEN_KEY);
+    broadcastAuthEvent({ type: 'logout' });
   } catch {
     // ignore storage failures (private mode, quota, etc.)
   }
+}
+
+// ── Multi-tab synchronization ────────────────────────────────────────────
+
+interface AuthBroadcastEvent {
+  type: 'tokens-updated' | 'logout';
+}
+
+function broadcastAuthEvent(event: AuthBroadcastEvent): void {
+  try {
+    const bc = new BroadcastChannel(AUTH_BROADCAST_CHANNEL);
+    bc.postMessage(event);
+    bc.close();
+  } catch {
+    // BroadcastChannel не поддерживается — fallback через storage event
+    try {
+      localStorage.setItem('scada.auth-event', JSON.stringify({ ...event, ts: Date.now() }));
+      localStorage.removeItem('scada.auth-event');
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/**
+ * Подписывается на события синхронизации auth между вкладками.
+ * @param onLogout callback при logout в другой вкладке
+ * @param onTokensUpdated callback при обновлении токенов в другой вкладке
+ * @returns функция отписки
+ */
+export function subscribeToAuthSync(onLogout: () => void, onTokensUpdated: () => void): () => void {
+  let bc: BroadcastChannel | null = null;
+
+  const handleMessage = (event: MessageEvent<AuthBroadcastEvent>) => {
+    if (event.data?.type === 'logout') {
+      onLogout();
+    } else if (event.data?.type === 'tokens-updated') {
+      onTokensUpdated();
+    }
+  };
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === 'scada.auth-event' && event.newValue) {
+      try {
+        const data = JSON.parse(event.newValue) as AuthBroadcastEvent;
+        if (data.type === 'logout') {
+          onLogout();
+        } else if (data.type === 'tokens-updated') {
+          onTokensUpdated();
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+  };
+
+  try {
+    bc = new BroadcastChannel(AUTH_BROADCAST_CHANNEL);
+    bc.addEventListener('message', handleMessage);
+  } catch {
+    // BroadcastChannel не поддерживается — используем storage event
+  }
+
+  window.addEventListener('storage', handleStorage);
+
+  return () => {
+    if (bc) {
+      bc.removeEventListener('message', handleMessage);
+      bc.close();
+    }
+    window.removeEventListener('storage', handleStorage);
+  };
 }

--- a/frontend/src/auth/token.ts
+++ b/frontend/src/auth/token.ts
@@ -1,0 +1,77 @@
+/**
+ * Утилиты для работы с JWT-токенами на клиенте.
+ *
+ * Парсит payload без валидации подписи (это задача сервера).
+ * Используется только для proactive-проверки срока действия.
+ */
+
+const TOKEN_EXPIRY_MARGIN_SECONDS = 300; // 5 минут запаса
+
+interface JwtPayload {
+  exp?: number;
+  sub?: string;
+  role?: string;
+}
+
+/**
+ * Декодирует JWT payload из base64url.
+ */
+function decodeJwtPayload(token: string): JwtPayload | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+    const json = atob(padded);
+    return JSON.parse(json) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Возвращает true, если токен истёк или истекает в ближайшие 5 минут.
+ */
+export function isTokenExpired(token: string | null): boolean {
+  if (!token) return true;
+  const payload = decodeJwtPayload(token);
+  if (!payload?.exp) return true;
+
+  const expiryWithMargin = payload.exp - TOKEN_EXPIRY_MARGIN_SECONDS;
+  return Math.floor(Date.now() / 1000) >= expiryWithMargin;
+}
+
+/**
+ * Возвращает true, если токен уже полностью истёк (без margin).
+ */
+export function isTokenFullyExpired(token: string | null): boolean {
+  if (!token) return true;
+  const payload = decodeJwtPayload(token);
+  if (!payload?.exp) return true;
+
+  return Math.floor(Date.now() / 1000) >= payload.exp;
+}
+
+/**
+ * Возвращает дату истечения токена или null.
+ */
+export function getTokenExpiryDate(token: string | null): Date | null {
+  if (!token) return null;
+  const payload = decodeJwtPayload(token);
+  if (!payload?.exp) return null;
+  return new Date(payload.exp * 1000);
+}
+
+/**
+ * Возвращает число секунд до истечения токена (с margin).
+ * Отрицательное значение = токен уже истёк.
+ */
+export function getTokenTimeRemaining(token: string | null): number {
+  if (!token) return -1;
+  const payload = decodeJwtPayload(token);
+  if (!payload?.exp) return -1;
+
+  const expiryWithMargin = payload.exp - TOKEN_EXPIRY_MARGIN_SECONDS;
+  return expiryWithMargin - Math.floor(Date.now() / 1000);
+}

--- a/frontend/src/auth/token.ts
+++ b/frontend/src/auth/token.ts
@@ -5,7 +5,7 @@
  * Используется только для proactive-проверки срока действия.
  */
 
-const TOKEN_EXPIRY_MARGIN_SECONDS = 300; // 5 минут запаса
+const TOKEN_EXPIRY_MARGIN_SECONDS = 60; // 1 минута запаса
 
 interface JwtPayload {
   exp?: number;
@@ -31,7 +31,7 @@ function decodeJwtPayload(token: string): JwtPayload | null {
 }
 
 /**
- * Возвращает true, если токен истёк или истекает в ближайшие 5 минут.
+ * Возвращает true, если токен истёк или истекает в ближайшие 1 минуту.
  */
 export function isTokenExpired(token: string | null): boolean {
   if (!token) return true;

--- a/frontend/src/config/ui.ts
+++ b/frontend/src/config/ui.ts
@@ -186,6 +186,7 @@ export const ERROR_MESSAGES = Object.freeze({
   serverError: 'Ошибка сервера. Повторите попытку',
   unexpectedError: 'Произошла непредвиденная ошибка',
   unknownError: 'Неизвестная ошибка',
+  sessionExpired: 'Сессия истекла. Войдите заново.',
   requestError: (status: number) => `Ошибка запроса (${status})`,
   unexpectedServerResponse: (status: number) => `Неожиданный ответ сервера (${status})`,
 });

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -18,7 +18,7 @@ import {
   setTokens,
   subscribeToAuthSync,
 } from '../auth/session';
-import { isTokenExpired, getTokenTimeRemaining } from '../auth/token';
+import { isTokenExpired, isTokenFullyExpired, getTokenTimeRemaining } from '../auth/token';
 import { refreshAccessToken } from '../api/auth';
 
 interface AuthContextValue {
@@ -178,7 +178,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const accessToken = getAccessToken();
-  const isTokenValid = Boolean(accessToken) && !isTokenExpired(accessToken);
+  const isTokenValid = Boolean(accessToken) && !isTokenFullyExpired(accessToken);
   const isAuthenticated = isTokenValid && Boolean(userId);
   const isAdmin = role === 'ADMIN';
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { ReactNode } from 'react';
 import {
   clearAllAuthData,
@@ -8,22 +16,141 @@ import {
   setStoredRole,
   setStoredUserId,
   setTokens,
+  subscribeToAuthSync,
 } from '../auth/session';
+import { isTokenExpired, getTokenTimeRemaining } from '../auth/token';
+import { refreshAccessToken } from '../api/auth';
 
 interface AuthContextValue {
   userId: string | null;
   role: string | null;
   isAuthenticated: boolean;
   isAdmin: boolean;
+  isVerifying: boolean;
   login: (userId: string, role: string, accessToken: string, refreshToken: string) => void;
   logout: () => void;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+/** Интервал проверки токена — каждые 60 секунд. */
+const TOKEN_CHECK_INTERVAL_MS = 60_000;
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [userId, setUserId] = useState<string | null>(() => getInitialUserId());
   const [role, setRole] = useState<string | null>(() => getStoredRole());
+  const [isVerifying, setIsVerifying] = useState(true);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ── Initial verification ───────────────────────────────────────────────
+  useEffect(() => {
+    const token = getAccessToken();
+    const storedUserId = getInitialUserId();
+
+    if (!token || !storedUserId) {
+      // Нет токена или userId — точно не аутентифицирован
+      if (token || storedUserId) {
+        clearAllAuthData();
+      }
+      setUserId(null);
+      setRole(null);
+      setIsVerifying(false);
+      return;
+    }
+
+    if (isTokenExpired(token)) {
+      // Токен истёк — пробуем refresh
+      refreshAccessToken()
+        .then((newToken) => {
+          if (!newToken) {
+            clearAllAuthData();
+            setUserId(null);
+            setRole(null);
+          }
+        })
+        .catch(() => {
+          clearAllAuthData();
+          setUserId(null);
+          setRole(null);
+        })
+        .finally(() => {
+          setIsVerifying(false);
+        });
+    } else {
+      setIsVerifying(false);
+    }
+  }, []);
+
+  // ── Multi-tab synchronization ──────────────────────────────────────────
+  useEffect(() => {
+    const unsubscribe = subscribeToAuthSync(
+      () => {
+        // Logout в другой вкладке — сбрасываем состояние
+        if (refreshTimerRef.current) {
+          clearTimeout(refreshTimerRef.current);
+          refreshTimerRef.current = null;
+        }
+        setUserId(null);
+        setRole(null);
+        setIsVerifying(false);
+      },
+      () => {
+        // Tokens обновились в другой вкладке — перечитываем userId/role
+        const updatedUserId = getInitialUserId();
+        const updatedRole = getStoredRole();
+        setUserId(updatedUserId);
+        setRole(updatedRole);
+      }
+    );
+    return unsubscribe;
+  }, []);
+
+  // ── Proactive refresh timer ────────────────────────────────────────────
+  useEffect(() => {
+    if (!userId) return;
+
+    function scheduleNextCheck(): void {
+      const token = getAccessToken();
+      if (!token) return;
+
+      const remaining = getTokenTimeRemaining(token);
+      if (remaining <= 0) {
+        // Токен уже истёк — refresh
+        void refreshAccessToken().then((newToken) => {
+          if (!newToken) {
+            clearAllAuthData();
+            setUserId(null);
+            setRole(null);
+          }
+        });
+        return;
+      }
+
+      // Планируем проверку: либо через стандартный интервал,
+      // либо за 10 секунд до истечения (чтобы успеть обновить)
+      const delay = Math.min(TOKEN_CHECK_INTERVAL_MS, Math.max(remaining * 1000 - 10_000, 5_000));
+      refreshTimerRef.current = setTimeout(() => {
+        void refreshAccessToken().then((newToken) => {
+          if (!newToken) {
+            clearAllAuthData();
+            setUserId(null);
+            setRole(null);
+            return;
+          }
+          scheduleNextCheck();
+        });
+      }, delay);
+    }
+
+    scheduleNextCheck();
+
+    return () => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+    };
+  }, [userId]);
 
   const login = useCallback(
     (nextUserId: string, nextRole: string, accessToken: string, refreshToken: string) => {
@@ -34,17 +161,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setRole(nextRole);
       setStoredRole(nextRole);
       setTokens(accessToken, refreshToken);
+      setIsVerifying(false);
     },
     []
   );
 
   const logout = useCallback(() => {
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+      refreshTimerRef.current = null;
+    }
     setUserId(null);
     setRole(null);
+    setIsVerifying(false);
     clearAllAuthData();
   }, []);
 
-  const isAuthenticated = Boolean(getAccessToken()) || Boolean(userId);
+  const accessToken = getAccessToken();
+  const isTokenValid = Boolean(accessToken) && !isTokenExpired(accessToken);
+  const isAuthenticated = isTokenValid && Boolean(userId);
   const isAdmin = role === 'ADMIN';
 
   const value = useMemo(
@@ -53,10 +188,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       role,
       isAuthenticated,
       isAdmin,
+      isVerifying,
       login,
       logout,
     }),
-    [userId, role, isAuthenticated, isAdmin, login, logout]
+    [userId, role, isAuthenticated, isAdmin, isVerifying, login, logout]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/errors/AppError.ts
+++ b/frontend/src/errors/AppError.ts
@@ -56,6 +56,7 @@ export type AppErrorCode =
   | 'parse_error' // SyntaxError при разборе JSON
   | 'validation_error' // ZodError — ответ не соответствует ожидаемой схеме
   | 'render_crash' // React ErrorBoundary
+  | 'session_expired' // JWT истёк, refresh не удался
   | 'unknown'; // Всё остальное
 
 // ── Основной тип ───────────────────────────────────────────────────────
@@ -101,6 +102,7 @@ export const ERROR_BODY_LABELS = Object.freeze({
   parse_error: 'Некорректный ответ сервера',
   validation_error: 'Некорректный формат данных',
   render_crash: 'Ошибка отображения',
+  session_expired: 'Сессия истекла. Войдите заново.',
   unknown: 'Произошла ошибка',
 } as const satisfies Record<AppErrorCode, string>);
 
@@ -131,5 +133,17 @@ export class HttpError extends Error {
   ) {
     super(message);
     this.name = 'HttpError';
+  }
+}
+
+/**
+ * Ошибка истечения сессии аутентификации.
+ * Выбрасывается когда refresh-токен тоже истёк или инвалидирован.
+ * Глобальный обработчик должен перенаправить пользователя на /login.
+ */
+export class AuthSessionExpiredError extends Error {
+  constructor(message = 'Сессия истекла') {
+    super(message);
+    this.name = 'AuthSessionExpiredError';
   }
 }

--- a/frontend/src/errors/classifyError.ts
+++ b/frontend/src/errors/classifyError.ts
@@ -27,7 +27,7 @@
 import { ZodError } from 'zod';
 import { ERROR_MESSAGES, HTTP_STATUS } from '../config';
 import type { AppError, AppErrorCode, AppErrorSeverity, AppErrorSource } from './AppError';
-import { HttpError } from './AppError';
+import { AuthSessionExpiredError, HttpError } from './AppError';
 
 // Внутренний тип: всё, что не зависит от источника.
 type ErrorResolution = Omit<AppError, 'source' | 'raw'>;
@@ -57,6 +57,16 @@ export function classifyError(raw: unknown, source: AppErrorSource): AppError {
  * Порядок имеет значение: от специфичных типов — к общим.
  */
 function resolveHandler(error: unknown): ErrorResolution {
+  // ── @ExceptionHandler(AuthSessionExpiredError.class) ─────────────────
+  // Сессия истекла, refresh не удался — нужен редирект на логин.
+  if (error instanceof AuthSessionExpiredError) {
+    return {
+      code: 'session_expired',
+      message: ERROR_MESSAGES.sessionExpired,
+      severity: 'critical',
+      retryable: false,
+    };
+  }
   // ── @ExceptionHandler(HttpError.class) ───────────────────────────────
   // HttpError — наш явный тип из api-слоя. Несёт статус-код числом.
   if (error instanceof HttpError) {

--- a/frontend/src/hooks/useLiveWs.ts
+++ b/frontend/src/hooks/useLiveWs.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { WS_BASE } from '../config';
 import { getAccessToken } from '../auth/session';
+import { isTokenExpired } from '../auth/token';
+import { refreshAccessToken } from '../api/auth';
 import { classifyError } from '../errors/classifyError';
 import type { AppError } from '../errors/AppError';
 import { createManagedWs, type ManagedWsConnection } from '../lib/createManagedWs';
@@ -93,6 +95,19 @@ export function useLiveWs(
       onReconnecting: () => callbacksRef.current.onReconnecting?.(),
       onError: (error) => callbacksRef.current.onError?.(error),
       onRecovered: () => callbacksRef.current.onRecovered?.(),
+
+      // onBeforeConnect вызывается перед каждой попыткой подключения.
+      // Позволяет обновить токен, если он истёк, избегая infinite reconnect loop.
+      onBeforeConnect: async () => {
+        const currentToken = getAccessToken();
+        if (currentToken && isTokenExpired(currentToken)) {
+          const newToken = await refreshAccessToken();
+          if (!newToken) {
+            // Refresh не удался — прерываем попытку подключения
+            throw new Error('Token refresh failed');
+          }
+        }
+      },
 
       // onOpen вызывается при каждом успешном подключении (в т.ч. после реконнекта).
       // Восстанавливаем подписку на цех, если она была активна в момент обрыва.

--- a/frontend/src/hooks/useUnitWs.ts
+++ b/frontend/src/hooks/useUnitWs.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { WS_BASE } from '../config';
 import { getAccessToken } from '../auth/session';
+import { isTokenExpired } from '../auth/token';
+import { refreshAccessToken } from '../api/auth';
 import { classifyError } from '../errors/classifyError';
 import type { AppError } from '../errors/AppError';
 import { createManagedWs } from '../lib/createManagedWs';
@@ -48,6 +50,19 @@ export function useUnitWs(
       onReconnecting: () => callbacksRef.current?.onReconnecting?.(),
       onError: (error) => callbacksRef.current?.onError?.(error),
       onRecovered: () => callbacksRef.current?.onRecovered?.(),
+
+      // onBeforeConnect вызывается перед каждой попыткой подключения.
+      // Позволяет обновить токен, если он истёк, избегая infinite reconnect loop.
+      onBeforeConnect: async () => {
+        const currentToken = getAccessToken();
+        if (currentToken && isTokenExpired(currentToken)) {
+          const newToken = await refreshAccessToken();
+          if (!newToken) {
+            throw new Error('Token refresh failed');
+          }
+        }
+      },
+
       onMessage: (e) => {
         let raw: unknown;
         try {

--- a/frontend/src/lib/createManagedWs.ts
+++ b/frontend/src/lib/createManagedWs.ts
@@ -41,6 +41,12 @@ export interface ManagedWsOptions {
   /** Источник ошибки для общей классификации. */
   source?: AppErrorSource;
   /**
+   * Вызывается асинхронно перед каждой попыткой подключения.
+   * Идеальное место для обновления токена, если он истёк.
+   * Если выбросит ошибку — попытка прерывается и считается неудачной.
+   */
+  onBeforeConnect?: () => Promise<void>;
+  /**
    * Вызывается при каждом успешном открытии соединения (включая реконнекты).
    * Идеальное место для восстановления подписок после обрыва.
    * Принимает свежий WebSocket-объект — можно сразу вызвать ws.send().
@@ -156,14 +162,18 @@ export function createManagedWs(options: ManagedWsOptions): ManagedWsConnection 
 
   // ── Основной connect-цикл ───────────────────────────────────────────
 
-  function connect(): void {
+  async function connect(): Promise<void> {
     if (destroyed) return;
 
     try {
+      // onBeforeConnect позволяет обновить токен перед подключением
+      if (options.onBeforeConnect) {
+        await options.onBeforeConnect();
+      }
+
       const url = typeof options.url === 'function' ? options.url() : options.url;
 
       if (import.meta.env.DEV) {
-         
         console.log(`[ws] connecting → ${url.replace(/\?token=.*/, '?token=***')}`);
       }
 
@@ -172,7 +182,6 @@ export function createManagedWs(options: ManagedWsOptions): ManagedWsConnection 
 
       ws.onopen = () => {
         if (import.meta.env.DEV) {
-           
           console.log(`[ws] open ← ${url.replace(/\?token=.*/, '?token=***')}`);
         }
         // Успешное подключение: сбрасываем счётчик неудач и задержку
@@ -186,7 +195,6 @@ export function createManagedWs(options: ManagedWsOptions): ManagedWsConnection 
 
       ws.onclose = () => {
         if (import.meta.env.DEV) {
-           
           console.log(`[ws] close ← ${url.replace(/\?token=.*/, '?token=***')}`);
         }
         handleFailure();
@@ -198,9 +206,9 @@ export function createManagedWs(options: ManagedWsOptions): ManagedWsConnection 
       ws.onerror = () => ws.close();
     } catch {
       // WebSocket-конструктор выбросил исключение (невалидный URL и т.п.)
+      // или onBeforeConnect выбросил ошибку (token refresh failed)
       if (import.meta.env.DEV) {
-         
-        console.error('[ws] constructor failed');
+        console.error('[ws] connection failed');
       }
       handleFailure();
       scheduleReconnect();
@@ -208,7 +216,7 @@ export function createManagedWs(options: ManagedWsOptions): ManagedWsConnection 
   }
 
   // ── Старт ──────────────────────────────────────────────────────────
-  connect();
+  void connect();
 
   // ── Публичный API ──────────────────────────────────────────────────
   return {


### PR DESCRIPTION
## Описание

Исправляет критическую проблему: при истечении срока access token (15 минут) приложение подвисало при обновлении страницы, не редиректило на логин, и возникали ошибки в консоли.

## Что изменено

### Backend
- **Access token lifetime**: увеличен с 15 минут до **24 часов** (`application.yaml`)
- **Hardcoded refresh expiry**: исправлен — теперь используется значение из `jwtProperties` вместо захардкоженных 7 дней
- **Custom AuthenticationEntryPoint**: консистентные 401-ответы в формате `AuthErrorResponseDTO`
- **Custom AccessDeniedHandler**: консистентные 403-ответы
- **Семантически правильные статусы**: `UserProfileController` и `NotificationSettingsController` теперь возвращают 401 (а не 400) при отсутствии аутентификации

### Frontend
- **JWT expiration parsing** (`auth/token.ts`): парсинг `exp` claim с 5-минутным proactive margin
- **Proactive refresh timer** в `AuthContext`: автоматическое обновление токена до истечения
- **Initial token verification**: при старте приложения проверяется валидность токена — expired токен сразу приводит к logout, без "authenticated flash"
- **Исправлена обработка refresh failure**: `apiFetch` теперь выбрасывает `AuthSessionExpiredError` вместо возврата 401 Response + `window.location.href`. Устраняет race condition между редиректом и ошибками в React
- **WebSocket token refresh**: `createManagedWs` получил `onBeforeConnect` hook — перед каждым reconnect проверяется и обновляется токен. Устраняет infinite reconnect loop с expired token
- **Multi-tab synchronization**: `BroadcastChannel` + `storage` events для синхронизации login/logout/token refresh между вкладками
- **Loading state в route guards**: `RequireAuth` и `RequireAdmin` показывают спиннер во время initial verification

## Как тестировать

1. Залогиниться, подождать >15 минут (или изменить system clock)
2. Обновить страницу — должно быть плавное перенаправление на `/login` без подвисаний
3. Открыть две вкладки — logout в одной должен сразу отразиться во второй
4. WebSocket reconnect при expired token должен обновить токен перед подключением

## Связанные issue

Closes #29