### PR TITLE
fix: каскадное удаление, flip меню строк и zebra-стили таблиц (#34, #36, #42)

### DIFF
--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUnitController.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUnitController.java
@@ -10,6 +10,8 @@ import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.en
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.DeviceCatalogJpaRepository;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.DeviceJpaRepository;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UnitJpaRepository;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UserAssignmentJpaRepository;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UserNotificationSettingsJpaRepository;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.WorkshopJpaRepository;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -39,6 +41,8 @@ public class AdminUnitController {
     private final WorkshopJpaRepository workshopRepository;
     private final DeviceJpaRepository deviceRepository;
     private final DeviceCatalogJpaRepository catalogRepository;
+    private final UserAssignmentJpaRepository assignmentRepository;
+    private final UserNotificationSettingsJpaRepository notificationSettingsRepository;
     private final PrintSrvTopologyJpaAdapter topologyJpaAdapter;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -46,12 +50,16 @@ public class AdminUnitController {
                                WorkshopJpaRepository workshopRepository,
                                DeviceJpaRepository deviceRepository,
                                DeviceCatalogJpaRepository catalogRepository,
+                               UserAssignmentJpaRepository assignmentRepository,
+                               UserNotificationSettingsJpaRepository notificationSettingsRepository,
                                PrintSrvTopologyJpaAdapter topologyJpaAdapter,
                                ApplicationEventPublisher eventPublisher) {
         this.unitRepository = unitRepository;
         this.workshopRepository = workshopRepository;
         this.deviceRepository = deviceRepository;
         this.catalogRepository = catalogRepository;
+        this.assignmentRepository = assignmentRepository;
+        this.notificationSettingsRepository = notificationSettingsRepository;
         this.topologyJpaAdapter = topologyJpaAdapter;
         this.eventPublisher = eventPublisher;
     }
@@ -126,6 +134,10 @@ public class AdminUnitController {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Аппарат не найден"));
         String printsrvInstanceId = unit.getPrintsrvInstanceId();
         Long workshopId = unit.getWorkshopId();
+        // Составная сущность «Автомат»: удаляем все оперативные записи,
+        // ссылающиеся на автомат, до удаления самой записи в units.
+        assignmentRepository.deleteByUnit_Id(id);
+        notificationSettingsRepository.deleteByUnit_Id(id);
         deviceRepository.deleteByUnit_Id(id);
         unitRepository.deleteById(id);
         topologyJpaAdapter.invalidateETag();

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUserController.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUserController.java
@@ -7,10 +7,12 @@ import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.en
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UnitEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UserAssignmentEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UserEntity;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.RefreshTokenJpaRepository;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.RoleJpaRepository;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UnitJpaRepository;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UserAssignmentJpaRepository;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UserJpaRepository;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UserNotificationSettingsJpaRepository;
 import dev.savushkin.scada.mobile.backend.domain.model.ChangeAction;
 import dev.savushkin.scada.mobile.backend.domain.model.EmployeeChangedEvent;
 import dev.savushkin.scada.mobile.backend.domain.model.UserAssignmentsChangedEvent;
@@ -48,6 +50,8 @@ public class AdminUserController {
     private final RoleJpaRepository roleRepository;
     private final UnitJpaRepository unitRepository;
     private final UserAssignmentJpaRepository assignmentRepository;
+    private final RefreshTokenJpaRepository refreshTokenRepository;
+    private final UserNotificationSettingsJpaRepository notificationSettingsRepository;
     private final EmployeeAccessService employeeAccessService;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -55,12 +59,16 @@ public class AdminUserController {
                                RoleJpaRepository roleRepository,
                                UnitJpaRepository unitRepository,
                                UserAssignmentJpaRepository assignmentRepository,
+                               RefreshTokenJpaRepository refreshTokenRepository,
+                               UserNotificationSettingsJpaRepository notificationSettingsRepository,
                                EmployeeAccessService employeeAccessService,
                                ApplicationEventPublisher eventPublisher) {
         this.userRepository = userRepository;
         this.roleRepository = roleRepository;
         this.unitRepository = unitRepository;
         this.assignmentRepository = assignmentRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.notificationSettingsRepository = notificationSettingsRepository;
         this.employeeAccessService = employeeAccessService;
         this.eventPublisher = eventPublisher;
     }
@@ -118,7 +126,11 @@ public class AdminUserController {
         if (!userRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Пользователь не найден");
         }
+        // Составная сущность «Сотрудник»: удаляем все оперативные записи,
+        // ссылающиеся на пользователя, до удаления самой записи в users.
         assignmentRepository.deleteByUser_Id(id);
+        notificationSettingsRepository.deleteByUser_Id(id);
+        refreshTokenRepository.deleteByUser_Id(id);
         userRepository.deleteById(id);
         eventPublisher.publishEvent(new EmployeeChangedEvent(id, ChangeAction.DELETE));
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/RefreshTokenJpaRepository.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/RefreshTokenJpaRepository.java
@@ -20,4 +20,6 @@ public interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenEnt
     @Modifying
     @Query("DELETE FROM RefreshTokenEntity r WHERE r.expiresAt < :before")
     void deleteByExpiresAtBefore(@Param("before") Instant before);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserAssignmentJpaRepository.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserAssignmentJpaRepository.java
@@ -56,5 +56,8 @@ public interface UserAssignmentJpaRepository extends JpaRepository<UserAssignmen
     void deleteByUser_Id(Long userId);
 
     @RestResource(exported = false)
+    void deleteByUnit_Id(Long unitId);
+
+    @RestResource(exported = false)
     Optional<UserAssignmentEntity> findByUnit_IdAndActiveTrue(Long unitId);
 }

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserNotificationSettingsJpaRepository.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserNotificationSettingsJpaRepository.java
@@ -48,4 +48,10 @@ public interface UserNotificationSettingsJpaRepository extends JpaRepository<Use
               and u.printsrvInstanceId is not null
             """)
     @NonNull Set<String> findAndroidCallEnabledPrintsrvUnitIdsByUserId(@Param("userId") Long userId);
+
+    @RestResource(exported = false)
+    void deleteByUser_Id(Long userId);
+
+    @RestResource(exported = false)
+    void deleteByUnit_Id(Long unitId);
 }

--- a/frontend/src/admin/components/UserNotificationSettingsEditor.tsx
+++ b/frontend/src/admin/components/UserNotificationSettingsEditor.tsx
@@ -244,7 +244,7 @@ export function UserNotificationSettingsEditor({ userId }: UserNotificationSetti
                         return (
                           <tr
                             key={row.unitId}
-                            className="border-b border-[#f0f0f0] last:border-b-0"
+                            className="border-b border-[#f0f0f0] last:border-b-0 even:bg-[#f8f9fa]"
                           >
                             <td className="py-3 pr-4 text-sm font-medium text-[#1a1c1e]">
                               {row.unitName}

--- a/frontend/src/admin/ui/DesktopDataTable.tsx
+++ b/frontend/src/admin/ui/DesktopDataTable.tsx
@@ -69,7 +69,7 @@ export function DesktopDataTable<T>({
               return (
                 <tr
                   key={keyExtractor(record, index)}
-                  className={`group border-b border-[#f0f0f0] last:border-b-0 ${
+                  className={`group border-b border-[#f0f0f0] last:border-b-0 even:bg-[#f8f9fa] ${
                     active
                       ? ''
                       : 'bg-[#f8f9fa] [&>td]:opacity-60 [&>td:first-child]:opacity-100 [&>td:last-child]:opacity-100'
@@ -78,7 +78,7 @@ export function DesktopDataTable<T>({
                   {allColumns.map((col) => (
                     <td
                       key={col.key}
-                      className={`py-3 pr-4 transition-colors duration-200 group-hover:bg-[#fafafa] first:rounded-l-[12px] last:rounded-r-[12px] ${col.className ?? ''}`}
+                      className={`py-3 pr-4 transition-colors duration-200 group-hover:bg-[#f0f7ff] first:rounded-l-[12px] last:rounded-r-[12px] ${col.className ?? ''}`}
                     >
                       {formatEmpty(col.render(record))}
                     </td>
@@ -118,9 +118,7 @@ function HeaderCell({ header, filterKey }: { header: ReactNode; filterKey?: stri
         <IconFilter
           size={14}
           className={`flex-none transition-colors ${
-            isActive
-              ? 'text-[#4285f4]'
-              : 'text-[#c4c7cc] group-hover/header:text-[#74777f]'
+            isActive ? 'text-[#4285f4]' : 'text-[#c4c7cc] group-hover/header:text-[#74777f]'
           }`}
         />
       </button>

--- a/frontend/src/admin/ui/Popover.tsx
+++ b/frontend/src/admin/ui/Popover.tsx
@@ -1,15 +1,26 @@
-import { useLayoutEffect, useState, type ReactNode, type RefObject } from 'react';
+import { useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { createPortal } from 'react-dom';
 
 const VIEWPORT_MARGIN = 8;
+const GAP = 4;
+const MIN_POPUP_HEIGHT = 160;
+
+const DEFAULT_PANEL_CLASSNAME =
+  'rounded-[16px] border border-[#e8eaed] bg-white p-3 normal-case shadow-[0_8px_24px_rgba(26,28,30,0.12)]';
 
 interface PopoverProps {
   open: boolean;
   onClose: () => void;
-  /** Элемент-якорь; попап позиционируется под его левым краем. */
+  /** Элемент-якорь; попап позиционируется относительно него. */
   anchorRef: RefObject<HTMLElement | null>;
   /** Ширина попапа в px (по умолчанию 256 = w-64). */
   width?: number;
+  /** К какому краю якоря прижимать попап по горизонтали. */
+  align?: 'left' | 'right';
+  /** Оформление панели; по умолчанию — стиль выпадающих фильтров. */
+  panelClassName?: string;
+  /** aria-label полноэкранной подложки, закрывающей попап кликом снаружи. */
+  closeLabel?: string;
   children: ReactNode;
 }
 
@@ -17,16 +28,28 @@ interface PopoverProps {
  * Выпадающий попап через портал в document.body с фиксированным
  * позиционированием относительно якоря.
  *
- * Решает две архитектурные проблемы выпадающих фильтров в таблицах:
+ * Решает три архитектурные проблемы выпадающих элементов в таблицах:
  *  - попап не является частью скролл-контейнера таблицы, поэтому никогда
  *    не растягивает его и не создаёт горизонтальную прокрутку;
  *  - позиция прижимается к краям viewport — попап не уезжает за экран
- *    даже у крайних правых колонок.
+ *    даже у крайних правых колонок;
+ *  - если под якорем не хватает места, попап открывается вверх (flip);
+ *    решение принимается по измеренной высоте контента, а не по оценке.
  *
  * Позиция пересчитывается при скролле (в любом контейнере) и resize.
  */
-export function Popover({ open, onClose, anchorRef, width = 256, children }: PopoverProps) {
+export function Popover({
+  open,
+  onClose,
+  anchorRef,
+  width = 256,
+  align = 'left',
+  panelClassName,
+  closeLabel = 'Закрыть',
+  children,
+}: PopoverProps) {
   const [pos, setPos] = useState<{ left: number; top: number; maxHeight: number } | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     if (!open) return;
@@ -35,14 +58,24 @@ export function Popover({ open, onClose, anchorRef, width = 256, children }: Pop
       const anchor = anchorRef.current;
       if (!anchor) return;
       const rect = anchor.getBoundingClientRect();
-      const top = rect.bottom + 4;
+      const contentHeight = panelRef.current?.offsetHeight ?? 0;
+      const spaceBelow = window.innerHeight - rect.bottom - GAP - VIEWPORT_MARGIN;
+      const spaceAbove = rect.top - GAP - VIEWPORT_MARGIN;
+      // Flip: если снизу не помещаемся и сверху места больше — открываем вверх.
+      const openUp = contentHeight > spaceBelow && spaceAbove > spaceBelow;
+      const available = openUp ? spaceAbove : spaceBelow;
       setPos({
         left: Math.max(
           VIEWPORT_MARGIN,
-          Math.min(rect.left, window.innerWidth - width - VIEWPORT_MARGIN)
+          Math.min(
+            align === 'right' ? rect.right - width : rect.left,
+            window.innerWidth - width - VIEWPORT_MARGIN
+          )
         ),
-        top,
-        maxHeight: Math.max(160, window.innerHeight - top - VIEWPORT_MARGIN),
+        top: openUp
+          ? Math.max(VIEWPORT_MARGIN, rect.top - GAP - Math.min(contentHeight, available))
+          : rect.bottom + GAP,
+        maxHeight: Math.max(MIN_POPUP_HEIGHT, available),
       });
     };
 
@@ -54,7 +87,7 @@ export function Popover({ open, onClose, anchorRef, width = 256, children }: Pop
       window.removeEventListener('scroll', update, true);
       window.removeEventListener('resize', update);
     };
-  }, [open, anchorRef, width]);
+  }, [open, anchorRef, width, align]);
 
   if (!open) return null;
 
@@ -62,13 +95,14 @@ export function Popover({ open, onClose, anchorRef, width = 256, children }: Pop
     <>
       <button
         type="button"
-        aria-label="Закрыть фильтр"
+        aria-label={closeLabel}
         onClick={onClose}
         className="fixed inset-0 z-20 cursor-default bg-transparent"
       />
       <div
+        ref={panelRef}
         role="dialog"
-        className="fixed z-30 overflow-y-auto rounded-[16px] border border-[#e8eaed] bg-white p-3 normal-case shadow-[0_8px_24px_rgba(26,28,30,0.12)]"
+        className={`fixed z-30 overflow-y-auto ${panelClassName ?? DEFAULT_PANEL_CLASSNAME}`}
         style={{
           left: pos?.left ?? VIEWPORT_MARGIN,
           top: pos?.top ?? 0,

--- a/frontend/src/admin/ui/RowActionsMenu.tsx
+++ b/frontend/src/admin/ui/RowActionsMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { ConfirmDialog } from './ConfirmDialog';
 import { IconDotsVertical, IconPencil, IconTrash, IconPower, IconPowerOff } from './icons';
+import { Popover } from './Popover';
 
 interface RowActionsMenuProps {
   onEdit?: () => void;
@@ -16,23 +17,9 @@ export function RowActionsMenu({
   onDelete,
 }: RowActionsMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [openUpward, setOpenUpward] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isOpen]);
 
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth < 1024);
@@ -49,80 +36,73 @@ export function RowActionsMenu({
     onDelete?.();
   };
 
-  // У нижних строк таблицы меню открываем вверх, иначе оно
-  // уходит за пределы экрана и добавляет лишнюю прокрутку.
-  const MENU_HEIGHT_ESTIMATE = 160;
-
-  const handleToggleOpen = () => {
-    if (!isOpen && buttonRef.current) {
-      const rect = buttonRef.current.getBoundingClientRect();
-      const spaceBelow = window.innerHeight - rect.bottom;
-      setOpenUpward(spaceBelow < MENU_HEIGHT_ESTIMATE && rect.top > spaceBelow);
-    }
-    setIsOpen((v) => !v);
-  };
-
   return (
-    <div ref={containerRef} className="relative ml-auto">
+    <div className="relative ml-auto">
       <button
         ref={buttonRef}
         type="button"
-        onClick={handleToggleOpen}
+        onClick={() => setIsOpen((v) => !v)}
         aria-label="Дополнительные действия"
+        aria-expanded={isOpen}
         className="flex h-9 w-9 items-center justify-center rounded-full text-[#74777f] transition-colors hover:bg-[#f0f7ff] hover:text-[#4285f4]"
       >
         <IconDotsVertical size={18} />
       </button>
 
-      {isOpen && (
-        <div
-          className={`absolute right-0 z-30 w-48 rounded-[14px] border border-[#e8eaed] bg-white py-1 shadow-[0_4px_16px_rgba(0,0,0,0.08)] ${
-            openUpward ? 'bottom-full mb-1' : 'top-full mt-1'
-          }`}
-        >
-          {onEdit && (
-            <button
-              type="button"
-              onClick={() => {
-                setIsOpen(false);
-                onEdit();
-              }}
-              className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-[#1a1c1e] transition-colors hover:bg-[#f8f9fa]"
-            >
-              <IconPencil size={16} />
-              Изменить
-            </button>
-          )}
+      {/* Меню рендерится порталом вне скролл-контейнера таблицы и само
+          выбирает сторону открытия: если снизу места нет — открывается
+          вверх (см. Popover). */}
+      <Popover
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        anchorRef={buttonRef}
+        width={192}
+        align="right"
+        closeLabel="Закрыть меню действий"
+        panelClassName="rounded-[14px] border border-[#e8eaed] bg-white py-1 shadow-[0_4px_16px_rgba(0,0,0,0.08)]"
+      >
+        {onEdit && (
+          <button
+            type="button"
+            onClick={() => {
+              setIsOpen(false);
+              onEdit();
+            }}
+            className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-[#1a1c1e] transition-colors hover:bg-[#f8f9fa]"
+          >
+            <IconPencil size={16} />
+            Изменить
+          </button>
+        )}
 
-          {hasToggle && (
-            <button
-              type="button"
-              onClick={() => {
-                setIsOpen(false);
-                onToggleActive();
-              }}
-              className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-[#1a1c1e] transition-colors hover:bg-[#f8f9fa]"
-            >
-              {isActive ? <IconPowerOff size={16} /> : <IconPower size={16} />}
-              {isActive ? 'Деактивировать' : 'Активировать'}
-            </button>
-          )}
+        {hasToggle && (
+          <button
+            type="button"
+            onClick={() => {
+              setIsOpen(false);
+              onToggleActive();
+            }}
+            className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-[#1a1c1e] transition-colors hover:bg-[#f8f9fa]"
+          >
+            {isActive ? <IconPowerOff size={16} /> : <IconPower size={16} />}
+            {isActive ? 'Деактивировать' : 'Активировать'}
+          </button>
+        )}
 
-          {hasDelete && (
-            <button
-              type="button"
-              onClick={() => {
-                setIsOpen(false);
-                setShowDeleteConfirm(true);
-              }}
-              className={`flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-[#ea4335] transition-colors hover:bg-[#fff0f1] ${onEdit || hasToggle ? 'mt-1 border-t border-[#f0f0f0]' : ''}`}
-            >
-              <IconTrash size={16} />
-              Удалить
-            </button>
-          )}
-        </div>
-      )}
+        {hasDelete && (
+          <button
+            type="button"
+            onClick={() => {
+              setIsOpen(false);
+              setShowDeleteConfirm(true);
+            }}
+            className={`flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-[#ea4335] transition-colors hover:bg-[#fff0f1] ${onEdit || hasToggle ? 'mt-1 border-t border-[#f0f0f0]' : ''}`}
+          >
+            <IconTrash size={16} />
+            Удалить
+          </button>
+        )}
+      </Popover>
 
       {hasDelete && (
         <ConfirmDialog

--- a/frontend/src/components/details/BatchTab.tsx
+++ b/frontend/src/components/details/BatchTab.tsx
@@ -52,7 +52,7 @@ export function BatchTab() {
 
   return (
     <TabContentState isLoading={isLoading} error={error} skeleton={<BatchTabSkeleton />}>
-      <div className="card p-5 card-static mb-4">
+      <div className="card p-5 card-static mb-4 zebra-list">
         <div className="card-title flex items-center gap-2">
           <img src="/assets/box.svg" alt="" aria-hidden="true" className="h-5 w-5" />
           {UI_COPY.batchTitle}
@@ -70,7 +70,7 @@ export function BatchTab() {
         </button>
 
         {expanded && (
-          <div style={BATCH_EXPANDED_SECTION_STYLE}>
+          <div style={BATCH_EXPANDED_SECTION_STYLE} className="zebra-list">
             {BATCH_ADDITIONAL_FIELDS.map(({ key, label, format }) => (
               <div key={key} className="kv-row">
                 <div className="kv-key">{label}</div>

--- a/frontend/src/components/details/LogsTab.tsx
+++ b/frontend/src/components/details/LogsTab.tsx
@@ -70,7 +70,7 @@ export function LogsTab() {
           )}
         </div>
 
-        <div className="card p-5 card-static mb-4">
+        <div className="card p-5 card-static mb-4 zebra-list">
           <div className="card-title flex items-center gap-2">
             <img src="/assets/pencil.svg" alt="" aria-hidden="true" className="h-5 w-5" />
             {UI_COPY.eventLogTitle}

--- a/frontend/src/components/details/QueueTab.tsx
+++ b/frontend/src/components/details/QueueTab.tsx
@@ -21,7 +21,7 @@ export function QueueTab() {
 
   return (
     <TabContentState isLoading={isLoading} error={error} skeleton={<QueueTabSkeleton />}>
-      <div className="card p-5 card-static mb-4">
+      <div className="card p-5 card-static mb-4 zebra-list">
         <div className="card-title flex items-center gap-2">
           <img src="/assets/list.svg" alt="" aria-hidden="true" className="h-5 w-5" />
           {UI_COPY.queueTitle}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -45,6 +45,8 @@
     --clr-divider: #f0f0f0;
     --clr-blue-light: #f0f7ff;
     --clr-border-soft: #e8eaed;
+    /* Фон чётных строк в табличных списках (zebra) */
+    --clr-row-alt: #f8f9fa;
 
     /*
       --app-height обновляется из JS (visualViewport / innerHeight).
@@ -323,6 +325,27 @@
   }
   .log-item:last-child {
     border-bottom: none;
+  }
+
+  /*
+    Zebra-чередование строк в табличных списках мониторинга
+    (детальные вкладки автомата). Контейнер списка помечается
+    классом .zebra-list; фон получает каждая чётная строка.
+    Паддинг и отрицательный margin расширяют фон строки в поля
+    карточки, не сдвигая текст; у всех строк одинаковые, чтобы
+    разделители и выравнивание не «прыгали».
+  */
+  .zebra-list > .kv-row,
+  .zebra-list > .queue-item,
+  .zebra-list > .log-item {
+    padding-inline: 10px;
+    margin-inline: -10px;
+  }
+  .zebra-list > .kv-row:nth-child(even),
+  .zebra-list > .queue-item:nth-child(even),
+  .zebra-list > .log-item:nth-child(even) {
+    background: var(--clr-row-alt);
+    border-radius: 10px;
   }
 
   .accordion-btn {


### PR DESCRIPTION
## Что сделано

### Closes #34 — каскадное удаление «Сотрудники» и «Автоматы»
Удаление падало с `409 Conflict` из-за FK без каскада. Теперь в транзакции удаляются все оперативные записи составной сущности:
- **Сотрудник:** назначения автоматов (`user_unit_assignments`), настройки уведомлений (`user_notification_settings`), refresh-токены (`refresh_tokens`).
- **Автомат:** назначения сотрудников, настройки уведомлений, связи с устройствами (`unit_devices`).

В `RefreshTokenJpaRepository`, `UserNotificationSettingsJpaRepository`, `UserAssignmentJpaRepository` добавлены недостающие `deleteByUser_Id` / `deleteByUnit_Id`.

### Closes #36 — меню строки уезжает за видимую область
`Popover` (уже используемый фильтрами: портал в `document.body`, fixed-позиционирование, пересчёт на scroll/resize) научился:
- **flip вверх**, если под якорем не хватает места — по измеренной высоте контента (магическая константа `MENU_HEIGHT_ESTIMATE` удалена);
- выравниванию по правому краю якоря (`align="right"`) и кастомному оформлению панели.

`RowActionsMenu` переведено на этот движок: меню рендерится порталом вне скролл-контейнера таблицы, поэтому больше не обрезается и не растягивает прокрутку у нижних строк.

### Closes #42 — zebra-стили таблиц
- **Админка:** `even:bg-[#f8f9fa]` для всех таблиц (`DesktopDataTable` + редактор настроек уведомлений); hover строки переведён с незаметного `#fafafa` на `#f0f7ff`, чтобы читался на сером фоне. Неактивные записи по-прежнему всегда серые + приглушение текста.
- **Мониторинг:** настоящих таблиц нет, zebra применена к строчным спискам детальных вкладок (`.kv-row`, `.queue-item`, `.log-item`) через класс-маркер `.zebra-list` и токен `--clr-row-alt` в `index.css`. Семантически окрашенные `.error-item` и карточки не тронуты.

## Проверка
- `gradlew compileJava`, `tsc -b --noEmit`, `eslint`, `npm run build` — чисто (husky-хуки на коммитах тоже прошли).
- Playwright, ручной прогон на dev-стенде:
  - #34: создан сотрудник с назначением + refresh-токеном + настройками → удаление через UI, в БД не осталось связанных записей; аналогично для автомата (назначение + настройки + устройства).
  - #36: при высоте окна 430px меню последней строки открывается вверх и целиком в пределах экрана.
  - #42: скриншоты таблиц «Сотрудники»/«Автоматы» и вкладки «Партия»; для «Журнала» — через тестовые элементы (живых логов в моке не было).