### PR TITLE
feat(admin): связанные записи при ошибке удаления, запрет привязок админу, UI-улучшения (#35, #39, #41)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,21 +116,25 @@
 
 Backend (Spring Boot, готово и используется):
 
-- `make back-run` — запустить backend в текущем терминале.
-- `make back-run-prod BACKEND_PORT=<port>` — запустить backend в prod-профиле на указанном порту.
+- `make back-run` — запустить backend в фоне (dev-профиль, порт `8080`). Если JWT-секреты не заданы в env, они автоматически генерируются в `backend/.env.dev` (игнорируется git). Лог пишется в `backend/.backend.log`.
+- `make back-wait` — дождаться, пока backend начнёт отвечать на порту.
+- `make back-stop` — остановить backend (вместе с процессом, слушающим порт).
+- `make back-logs` — смотреть лог backend (`tail -f backend/.backend.log`).
+- `make back-run-prod` — запустить backend в prod-профиле (порт и секреты берутся из `PROD_ENV_FILE`, по умолчанию `.env.prod.local`).
+
+Типовой цикл локального запуска: `make back-run && make back-wait`.
 
 Docker:
 
-- `make docker-dev-up` — поднять docker-стек в dev-режиме.
-- `make docker-dev-down` — остановить dev-стек.
 - `make docker-prod-up` — поднять docker-стек в prod-режиме (использует `PROD_ENV_FILE`, по умолчанию `.env.prod.local`).
 - `make docker-prod-down` — остановить prod-стек.
 - `make docker-ps` — показать статус контейнеров.
 
 Примечания:
 
+- Makefile работает и в Git Bash на Windows (POSIX-рецепты), и на Linux; для нативного cmd/PowerShell остаются Windows-ветки. На Windows prod-стек через `make docker-prod-up` не поднимается — только WSL2 или Linux-сервер.
 - По умолчанию `make back-run` использует dev-профиль и порт `8080`.
-- Для prod-режима порт обязателен: `make back-run-prod BACKEND_PORT=8080`.
+- Для prod-режима порт и секреты обязательны в `PROD_ENV_FILE` (`SCADA_MOBILE_BACKEND_PORT`, `SCADA_MOBILE_JWT_ACCESS_SECRET`, `SCADA_MOBILE_JWT_REFRESH_SECRET`).
 
 Frontend:
 

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,25 @@ SEED_DB_PASSWORD ?= scada_password
 SEED_SQL ?= scripts/seed_notifications.sql
 SEED_PROD_SQL ?= scripts/seed_prod_data.sql
 
+# Локальный файл с автогенерируемыми dev JWT-секретами (игнорируется git через .env.*)
+DEV_SECRETS_FILE := .env.dev
+DEV_BACKEND_LOG := .backend.log
+API_BASE_PATH ?= /api/v1.0.0
 
-ifeq ($(OS),Windows_NT)
+# POSIX-окружение (Linux/macOS/Git Bash/MSYS/Cygwin) определяем по uname,
+# а не по переменной OS: в Git Bash OS=Windows_NT, но доступны sh-утилиты.
+UNAME_S := $(shell uname -s 2>/dev/null)
+IS_POSIX := $(if $(UNAME_S),1,)
+# Git Bash/MSYS/Cygwin на Windows
+IS_MINGW := $(if $(filter MINGW% MSYS% CYGWIN%,$(UNAME_S)),1,)
+
+ifeq ($(IS_POSIX),)
 GRADLEW := gradlew.bat
 else
 GRADLEW := ./gradlew
 endif
 
-.PHONY: help back-run back-stop back-run-prod front-install front-dev front-build db-seed db-seed-prod
+.PHONY: help back-run back-stop back-wait back-logs back-run-prod front-install front-dev front-build db-seed db-seed-prod
 .PHONY: bwa-init bwa-build-apk
 .PHONY: docker-prod-up docker-prod-down docker-ps
 
@@ -29,13 +40,14 @@ PROD_ENV_FILE ?= .env.prod.local
 PROD_ENV_FALLBACK := .env.prod.example
 PROD_ENV_ACTIVE_FILE = $(if $(wildcard $(PROD_ENV_FILE)),$(PROD_ENV_FILE),$(PROD_ENV_FALLBACK))
 
-ifeq ($(OS),Windows_NT)
 help:
 	@echo "SCADA Mobile shortcuts"
 	@echo ""
 	@echo "Backend:"
 	@echo "  make back-run       - run backend in background [dev profile, port $(DEV_BACKEND_PORT), Swagger enabled]"
-	@echo "  make back-stop      - stop backend started by back-run"
+	@echo "  make back-stop      - stop backend started by back-run (also kills the listener on port $(DEV_BACKEND_PORT))"
+	@echo "  make back-wait      - wait until backend responds on port $(DEV_BACKEND_PORT)"
+	@echo "  make back-logs      - tail backend log ($(BACKEND_DIR)/$(DEV_BACKEND_LOG))"
 	@echo "  make back-run-prod  - run backend [prod profile, port from SCADA_MOBILE_BACKEND_PORT, Swagger disabled]"
 	@echo ""
 	@echo "Docker:"
@@ -53,33 +65,8 @@ help:
 	@echo "Bubblewrap (Android):"
 	@echo "  make bwa-init      - create/re-init TWA project in android folder"
 	@echo "  make bwa-build-apk - build APK via bubblewrap"
-else
-help:
-	@echo "SCADA Mobile shortcuts"
-	@echo ""
-	@echo "Backend:"
-	@echo "  make back-run       - run backend in background [dev profile, port $(DEV_BACKEND_PORT), Swagger enabled]"
-	@echo "  make back-stop      - stop backend started by back-run"
-	@echo "  make back-run-prod  - run backend [prod profile, port from SCADA_MOBILE_BACKEND_PORT, Swagger disabled]"
-	@echo ""
-	@echo "Docker:"
-	@echo "  make docker-prod-up   - start docker stack (prod mode) (env: PROD_ENV_FILE=.env.prod.local)"
-	@echo "  make docker-prod-down - stop docker stack (prod mode)"
-	@echo "  make docker-ps        - show container status for the active stack"
-	@echo "  make db-seed          - seed dev database via docker exec (container: $(SEED_DB_CONTAINER_DEV), env: SEED_DB_NAME, SEED_DB_USER, SEED_DB_PASSWORD)"
-	@echo "  make db-seed-prod     - seed production database (container: $(SEED_DB_CONTAINER_PROD), workshops/units/device_types from env vars)"
-	@echo ""
-	@echo "Frontend:"
-	@echo "  make front-install - install frontend dependencies"
-	@echo "  make front-dev     - start frontend dev server (port $(DEV_FRONTEND_PORT), strict)"
-	@echo "  make front-build   - build frontend for production"
-	@echo ""
-	@echo "Bubblewrap (Android):"
-	@echo "  make bwa-init      - create/re-init TWA project in android folder"
-	@echo "  make bwa-build-apk - build APK via bubblewrap"
-endif
 
-ifeq ($(OS),Windows_NT)
+ifeq ($(IS_POSIX),)
 back-run:
 	powershell -NoProfile -Command "$$env:JAVA_TOOL_OPTIONS='$(JAVA_OPTS)'; $$env:SPRING_PROFILES_ACTIVE='dev'; $$env:SERVER_PORT='$(DEV_BACKEND_PORT)'; $$env:SCADA_MOBILE_JWT_ACCESS_SECRET='$(SCADA_MOBILE_JWT_ACCESS_SECRET)'; $$env:SCADA_MOBILE_JWT_REFRESH_SECRET='$(SCADA_MOBILE_JWT_REFRESH_SECRET)'; $$p = Start-Process -FilePath '.\\gradlew.bat' -ArgumentList 'bootRun' -WorkingDirectory '$(BACKEND_DIR)' -PassThru; $$p.Id | Set-Content '$(BACKEND_DIR)\\.backend.pid'"
 
@@ -96,14 +83,57 @@ db-seed-prod:
 	powershell -NoProfile -ExecutionPolicy Bypass -File scripts\seed_prod.ps1 -EnvFile '$(PROD_ENV_ACTIVE_FILE)' -SeedSql '$(SEED_PROD_SQL)' -Container '$(SEED_DB_CONTAINER_PROD)'
 else
 back-run:
-	cd $(BACKEND_DIR) && chmod +x ./gradlew && JAVA_TOOL_OPTIONS='$(JAVA_OPTS)' SPRING_PROFILES_ACTIVE=dev SERVER_PORT='$(DEV_BACKEND_PORT)' SCADA_MOBILE_JWT_ACCESS_SECRET='$(SCADA_MOBILE_JWT_ACCESS_SECRET)' SCADA_MOBILE_JWT_REFRESH_SECRET='$(SCADA_MOBILE_JWT_REFRESH_SECRET)' nohup $(GRADLEW) bootRun > .backend.log 2>&1 & echo $$! > .backend.pid
+	@cd $(BACKEND_DIR) && \
+	if [ -z "$(SCADA_MOBILE_JWT_ACCESS_SECRET)" ] || [ -z "$(SCADA_MOBILE_JWT_REFRESH_SECRET)" ]; then \
+		if [ ! -f "$(DEV_SECRETS_FILE)" ]; then \
+			echo "Generating dev JWT secrets into $(BACKEND_DIR)/$(DEV_SECRETS_FILE) (git-ignored)..."; \
+			umask 077; \
+			printf 'SCADA_MOBILE_JWT_ACCESS_SECRET=%s\n' "$$(openssl rand -base64 48 | tr -d '\n')" > "$(DEV_SECRETS_FILE)"; \
+			printf 'SCADA_MOBILE_JWT_REFRESH_SECRET=%s\n' "$$(openssl rand -base64 48 | tr -d '\n')" >> "$(DEV_SECRETS_FILE)"; \
+		fi; \
+		set -a; . "./$(DEV_SECRETS_FILE)"; set +a; \
+	else \
+		SCADA_MOBILE_JWT_ACCESS_SECRET='$(SCADA_MOBILE_JWT_ACCESS_SECRET)'; \
+		SCADA_MOBILE_JWT_REFRESH_SECRET='$(SCADA_MOBILE_JWT_REFRESH_SECRET)'; \
+		export SCADA_MOBILE_JWT_ACCESS_SECRET SCADA_MOBILE_JWT_REFRESH_SECRET; \
+	fi; \
+	chmod +x ./gradlew; \
+	JAVA_TOOL_OPTIONS='$(JAVA_OPTS)' SPRING_PROFILES_ACTIVE=dev SERVER_PORT='$(DEV_BACKEND_PORT)' \
+	nohup $(GRADLEW) bootRun > $(DEV_BACKEND_LOG) 2>&1 & echo $$! > .backend.pid
+	@echo "Backend starting in background (log: $(BACKEND_DIR)/$(DEV_BACKEND_LOG)). Use 'make back-wait' to wait for readiness."
 
 back-stop:
 	@if [ -f "$(BACKEND_DIR)/.backend.pid" ]; then \
-		kill $$(cat "$(BACKEND_DIR)/.backend.pid") && rm "$(BACKEND_DIR)/.backend.pid"; \
+		kill $$(cat "$(BACKEND_DIR)/.backend.pid") 2>/dev/null || true; \
+		rm -f "$(BACKEND_DIR)/.backend.pid"; \
 	else \
 		echo "No backend PID file found."; \
 	fi
+	@# gradlew/bootRun leaves a child JVM holding the port: finish off the listener
+	@if [ -n "$(IS_MINGW)" ]; then \
+		for pid in $$(netstat -ano | grep LISTENING | grep -E ':$(DEV_BACKEND_PORT)[[:space:]]' | awk '{print $$NF}' | sort -u); do \
+			echo "Killing listener on port $(DEV_BACKEND_PORT) (PID $$pid)..."; \
+			taskkill //F //PID $$pid > /dev/null 2>&1 || true; \
+		done; \
+	else \
+		fuser -k $(DEV_BACKEND_PORT)/tcp 2>/dev/null || true; \
+	fi
+
+back-wait:
+	@echo "Waiting for backend on port $(DEV_BACKEND_PORT)..."; \
+	for i in $$(seq 1 60); do \
+		code=$$(curl -s -o /dev/null -w '%{http_code}' -X POST "http://localhost:$(DEV_BACKEND_PORT)$(API_BASE_PATH)/auth/login" -H 'Content-Type: application/json' -d '{}' 2>/dev/null); \
+		if [ "$$code" != "000" ]; then \
+			echo "backend is UP (HTTP $$code)"; \
+			exit 0; \
+		fi; \
+		sleep 5; \
+	done; \
+	echo "backend did not respond in time"; \
+	exit 1
+
+back-logs:
+	tail -n 200 -f "$(BACKEND_DIR)/$(DEV_BACKEND_LOG)"
 
 back-run-prod:
 	@set -a; \
@@ -164,7 +194,7 @@ db-seed-prod:
 		psql -U "$$SCADA_MOBILE_POSTGRES_USER" -d "$$SCADA_MOBILE_POSTGRES_DB" -v ON_ERROR_STOP=1 -f - < "$(SEED_PROD_SQL)"
 endif
 
-ifeq ($(OS),Windows_NT)
+ifeq ($(IS_POSIX),)
 front-install:
 	cmd /C "cd $(FRONTEND_DIR) && npm install"
 
@@ -196,7 +226,7 @@ bwa-build-apk:
 	cd android && npx @bubblewrap/cli build
 endif
 
-ifeq ($(OS),Windows_NT)
+ifeq ($(IS_POSIX),)
 docker-prod-up:
 	@echo "Ошибка: запуск prod-стека на Windows не поддерживается."
 	@echo "Используйте WSL2 (Ubuntu) или разворачивайте на Linux-сервере."
@@ -210,6 +240,11 @@ docker-ps:
 else
 
 docker-prod-up:
+	@if [ -n "$(IS_MINGW)" ]; then \
+		echo "Ошибка: запуск prod-стека на Windows не поддерживается."; \
+		echo "Используйте WSL2 (Ubuntu) или разворачивайте на Linux-сервере."; \
+		exit 1; \
+	fi
 	@if [ ! -f "$(PROD_ENV_FILE)" ]; then \
 		echo "Missing $(PROD_ENV_FILE). Copy .env.prod.example -> $(PROD_ENV_FILE) and fill values."; \
 		exit 1; \

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -60,7 +60,9 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-webmvc-test")
-    runtimeOnly("org.postgresql:postgresql")
+    // implementation (не runtimeOnly): нужен compile-time доступ к org.postgresql.util.PSQLException
+    // для извлечения имени FK-констрейнта/detail при обработке ошибок удаления (issue #35)
+    implementation("org.postgresql:postgresql")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // Mockito Agent jar (используем ту же версию, что резолвится для тестов через BOM Spring).

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUnitController.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUnitController.java
@@ -1,11 +1,14 @@
 package dev.savushkin.scada.mobile.backend.api.controller.admin;
 
+import dev.savushkin.scada.mobile.backend.api.dto.ErrorResponseDTO;
+import dev.savushkin.scada.mobile.backend.api.dto.ReferenceDTO;
 import dev.savushkin.scada.mobile.backend.domain.model.ChangeAction;
 import dev.savushkin.scada.mobile.backend.domain.model.UnitChangedEvent;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.adapter.PrintSrvTopologyJpaAdapter;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.DeviceCatalogEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.DeviceEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UnitEntity;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UserAssignmentEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.WorkshopEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.DeviceCatalogJpaRepository;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.DeviceJpaRepository;
@@ -13,6 +16,7 @@ import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.re
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UserAssignmentJpaRepository;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UserNotificationSettingsJpaRepository;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.WorkshopJpaRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -129,9 +133,23 @@ public class AdminUnitController {
 
     @DeleteMapping("/{id}")
     @Transactional
-    public ResponseEntity<Void> delete(@PathVariable @NonNull Long id) {
+    public ResponseEntity<?> delete(@PathVariable @NonNull Long id, HttpServletRequest request) {
         UnitEntity unit = unitRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Аппарат не найден"));
+        // Автомат, закреплённый хотя бы за одним сотрудником, удалять нельзя:
+        // возвращаем 409 со списком сотрудников, чтобы их отвязали перед удалением.
+        List<UserAssignmentEntity> activeAssignments =
+                assignmentRepository.findTop10ByUnit_IdAndActiveTrueOrderByIdAsc(id);
+        if (!activeAssignments.isEmpty()) {
+            List<ReferenceDTO> references = activeAssignments.stream()
+                    .map(a -> new ReferenceDTO("users", "Сотрудники", a.getUser().getId(),
+                            a.getUser().getFullName()))
+                    .toList();
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorResponseDTO(
+                    HttpStatus.CONFLICT.value(),
+                    "Невозможно удалить запись, так как она используется другими объектами системы",
+                    request.getRequestURI(), null, references));
+        }
         String printsrvInstanceId = unit.getPrintsrvInstanceId();
         Long workshopId = unit.getWorkshopId();
         // Составная сущность «Автомат»: удаляем все оперативные записи,

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUserAssignmentController.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUserAssignmentController.java
@@ -1,5 +1,8 @@
 package dev.savushkin.scada.mobile.backend.api.controller.admin;
 
+import dev.savushkin.scada.mobile.backend.config.AdminBootstrapConfig;
+import dev.savushkin.scada.mobile.backend.exception.UnitAssignmentConflictException;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.RoleEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UnitEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UserAssignmentEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UserEntity;
@@ -53,6 +56,8 @@ public class AdminUserAssignmentController {
         UnitEntity unit = unitRepository.findById(request.unitId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Аппарат не найден"));
 
+        rejectAdminAssignment(user);
+
         UserAssignmentEntity assignment = new UserAssignmentEntity();
         assignment.setUser(user);
         assignment.setUnit(unit);
@@ -77,6 +82,14 @@ public class AdminUserAssignmentController {
         UnitEntity unit = unitRepository.findById(request.unitId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Аппарат не найден"));
 
+        // Отказ только при реальном изменении привязки; no-op обновление
+        // (например, смена только флага active) разрешено даже для админа.
+        boolean assignmentChanged = !request.userId().equals(assignment.getUserId())
+                || !request.unitId().equals(assignment.getUnitId());
+        if (assignmentChanged) {
+            rejectAdminAssignment(user);
+        }
+
         assignment.setUser(user);
         assignment.setUnit(unit);
         assignment.setActive(request.active());
@@ -97,6 +110,18 @@ public class AdminUserAssignmentController {
         eventPublisher.publishEvent(new UserAssignmentsChangedEvent(userId));
         eventPublisher.publishEvent(new EmployeeChangedEvent(userId, ChangeAction.UPDATE));
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Проверяет, что пользователю можно назначать автоматы:
+     * пользователь с ролью «Админ» не должен иметь закреплённых автоматов.
+     */
+    private void rejectAdminAssignment(UserEntity user) {
+        RoleEntity role = user.getRole();
+        if (role != null && AdminBootstrapConfig.ADMIN_ROLE_NAME.equals(role.getName())) {
+            throw new UnitAssignmentConflictException("unitIds",
+                    "Нельзя закреплять автоматы за пользователем с ролью «Админ»");
+        }
     }
 
     public record AssignmentRequest(

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUserController.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUserController.java
@@ -2,6 +2,7 @@ package dev.savushkin.scada.mobile.backend.api.controller.admin;
 
 import dev.savushkin.scada.mobile.backend.api.dto.admin.PasswordResetResponseDTO;
 import dev.savushkin.scada.mobile.backend.api.dto.admin.UserCreateResponseDTO;
+import dev.savushkin.scada.mobile.backend.config.AdminBootstrapConfig;
 import dev.savushkin.scada.mobile.backend.exception.UnitAssignmentConflictException;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.RoleEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UnitEntity;
@@ -160,6 +161,25 @@ public class AdminUserController {
         }
 
         Set<Long> uniqueUnitIds = new HashSet<>(unitIds);
+
+        // Пользователь с ролью «Админ» не должен иметь закреплённых автоматов.
+        // Отказ только при добавлении новых назначений: пустой список или
+        // удаление существующих (legacy) привязок разрешены.
+        RoleEntity userRole = user.getRole();
+        if (userRole != null && AdminBootstrapConfig.ADMIN_ROLE_NAME.equals(userRole.getName())) {
+            Set<Long> existingUnitIds = new HashSet<>();
+            for (UserAssignmentEntity existing : assignmentRepository.findByUser_Id(user.getId())) {
+                if (existing.getUnit() != null) {
+                    existingUnitIds.add(existing.getUnit().getId());
+                }
+            }
+            Set<Long> newUnitIds = new HashSet<>(uniqueUnitIds);
+            newUnitIds.removeAll(existingUnitIds);
+            if (!newUnitIds.isEmpty()) {
+                throw new UnitAssignmentConflictException("unitIds",
+                        "Нельзя закреплять автоматы за пользователем с ролью «Админ»");
+            }
+        }
 
         // Валидация: каждый автомат может быть назначен только одному сотруднику
         for (Long unitId : uniqueUnitIds) {

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/dto/ErrorResponseDTO.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/dto/ErrorResponseDTO.java
@@ -1,6 +1,9 @@
 package dev.savushkin.scada.mobile.backend.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -12,7 +15,9 @@ public record ErrorResponseDTO(
         String message,
         LocalDateTime timestamp,
         String path,
-        Map<String, String> errors
+        Map<String, String> errors,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        List<ReferenceDTO> references
 ) {
     /**
      * Конструктор с автоматической установкой текущего времени.
@@ -22,7 +27,7 @@ public record ErrorResponseDTO(
      * @param path    путь к endpoint, где произошла ошибка
      */
     public ErrorResponseDTO(int status, String message, String path) {
-        this(status, message, LocalDateTime.now(), path, null);
+        this(status, message, LocalDateTime.now(), path, null, null);
     }
 
     /**
@@ -34,6 +39,21 @@ public record ErrorResponseDTO(
      * @param errors  ошибки по полям формы
      */
     public ErrorResponseDTO(int status, String message, String path, Map<String, String> errors) {
-        this(status, message, LocalDateTime.now(), path, errors);
+        this(status, message, LocalDateTime.now(), path, errors, null);
+    }
+
+    /**
+     * Конструктор со списком ссылающихся записей (для ошибок удаления по FK).
+     *
+     * @param status     HTTP статус-код
+     * @param message    описание ошибки
+     * @param path       путь к endpoint, где произошла ошибка
+     * @param errors     ошибки по полям формы
+     * @param references записи, ссылающиеся на удаляемый объект
+     *                   (null, если ошибка не связана с внешним ключом)
+     */
+    public ErrorResponseDTO(int status, String message, String path, Map<String, String> errors,
+                            List<ReferenceDTO> references) {
+        this(status, message, LocalDateTime.now(), path, errors, references);
     }
 }

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/dto/ReferenceDTO.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/dto/ReferenceDTO.java
@@ -1,0 +1,25 @@
+package dev.savushkin.scada.mobile.backend.api.dto;
+
+/**
+ * DTO с информацией о записи, ссылающейся на удаляемый объект.
+ * <p>
+ * Используется в {@link ErrorResponseDTO#references()} при ошибке удаления
+ * записи, на которую есть ссылки по внешнему ключу (FK-violation, SQLState 23503),
+ * чтобы клиент мог показать пользователю, кто именно ссылается на запись.
+ *
+ * @param type      машинное имя ресурса в стиле роутов админки
+ *                  (users, units, device-catalog, user-assignments,
+ *                  user-notification-settings, unit-devices)
+ * @param typeLabel русское название ресурса во множественном числе
+ *                  («Сотрудники», «Автоматы», «Каталог устройств»,
+ *                  «Привязки автоматов», «Настройки уведомлений», «Устройства»)
+ * @param id        идентификатор ссылающейся записи
+ * @param name      человекочитаемое отображаемое имя записи
+ */
+public record ReferenceDTO(
+        String type,
+        String typeLabel,
+        Long id,
+        String name
+) {
+}

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/config/AdminBootstrapConfig.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/config/AdminBootstrapConfig.java
@@ -34,7 +34,7 @@ import java.nio.charset.StandardCharsets;
 public class AdminBootstrapConfig implements ApplicationRunner {
 
     private static final Logger log = LoggerFactory.getLogger(AdminBootstrapConfig.class);
-    private static final String ADMIN_ROLE_NAME = "ADMIN";
+    public static final String ADMIN_ROLE_NAME = "ADMIN";
     private static final String BOOTSTRAP_SCRIPT = "classpath:db/bootstrap/bootstrap_admin.sql";
 
     private final UserJpaRepository userRepository;

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/exception/DeleteReferenceResolver.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/exception/DeleteReferenceResolver.java
@@ -1,0 +1,218 @@
+package dev.savushkin.scada.mobile.backend.exception;
+
+import dev.savushkin.scada.mobile.backend.api.dto.ReferenceDTO;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.DeviceCatalogEntity;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.DeviceEntity;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UnitEntity;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UserAssignmentEntity;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UserEntity;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UserNotificationSettingsEntity;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.DeviceCatalogJpaRepository;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.DeviceJpaRepository;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UnitJpaRepository;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UserAssignmentJpaRepository;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UserJpaRepository;
+import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.repository.UserNotificationSettingsJpaRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.ServerErrorMessage;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Извлекает из {@link DataIntegrityViolationException} (FK-violation, SQLState 23503)
+ * список записей, ссылающихся на удаляемую, чтобы клиент мог показать,
+ * кто именно использует запись.
+ * <p>
+ * Имя FK-констрейнта и detail берутся из {@link ServerErrorMessage} PostgreSQL.
+ * По имени констрейнта выбирается запрос к соответствующему репозиторию
+ * (первые 10 записей, сортировка по id).
+ * <p>
+ * Компонент «безопасный»: при неизвестном констрейнте, нераспарсившемся detail
+ * или любой внутренней ошибке возвращает {@code null} — обработчик исключений
+ * должен в этом случае отдать обычный ответ без ссылок.
+ */
+@Slf4j
+@Component
+public class DeleteReferenceResolver {
+
+    /**
+     * Detail PostgreSQL имеет вид:
+     * {@code Key (role_id)=(3) is still referenced from table "users".}
+     */
+    private static final Pattern DETAIL_KEY_PATTERN = Pattern.compile("\\((\\w+)\\)=\\((\\d+)\\)");
+
+    // Имена констрейнтов — из миграций V1__init.sql и V6__refactor_device_catalog.sql.
+    // PostgreSQL складывает некавыченные идентификаторы в нижний регистр,
+    // поэтому сравнение ведётся в lower case.
+    private static final String FK_USERS_ON_ROLE = "fk_users_on_role";
+    private static final String FK_UNITS_ON_WORKSHOP = "fk_units_on_workshop";
+    private static final String FK_USER_UNIT_ASSIGNMENTS_ON_USER = "fk_user_unit_assignments_on_user";
+    private static final String FK_USER_UNIT_ASSIGNMENTS_ON_UNIT = "fk_user_unit_assignments_on_unit";
+    private static final String FK_USER_NOTIFICATION_SETTINGS_ON_USER = "fk_user_notification_settings_on_user";
+    private static final String FK_USER_NOTIFICATION_SETTINGS_ON_UNIT = "fk_user_notification_settings_on_unit";
+    private static final String FK_DEVICE_CATALOG_ON_TYPE = "fk_device_catalog_on_type";
+    private static final String FK_UNIT_DEVICES_ON_UNIT = "fk_unit_devices_on_unit";
+    private static final String FK_UNIT_DEVICES_ON_CATALOG = "fk_unit_devices_on_catalog";
+
+    private static final String TYPE_USERS = "users";
+    private static final String TYPE_UNITS = "units";
+    private static final String TYPE_DEVICE_CATALOG = "device-catalog";
+    private static final String TYPE_USER_ASSIGNMENTS = "user-assignments";
+    private static final String TYPE_USER_NOTIFICATION_SETTINGS = "user-notification-settings";
+    private static final String TYPE_UNIT_DEVICES = "unit-devices";
+
+    private static final String LABEL_USERS = "Сотрудники";
+    private static final String LABEL_UNITS = "Автоматы";
+    private static final String LABEL_DEVICE_CATALOG = "Каталог устройств";
+    private static final String LABEL_USER_ASSIGNMENTS = "Привязки автоматов";
+    private static final String LABEL_USER_NOTIFICATION_SETTINGS = "Настройки уведомлений";
+    private static final String LABEL_UNIT_DEVICES = "Устройства";
+
+    private final UserJpaRepository userRepository;
+    private final UnitJpaRepository unitRepository;
+    private final UserAssignmentJpaRepository assignmentRepository;
+    private final UserNotificationSettingsJpaRepository notificationSettingsRepository;
+    private final DeviceJpaRepository deviceRepository;
+    private final DeviceCatalogJpaRepository deviceCatalogRepository;
+
+    public DeleteReferenceResolver(UserJpaRepository userRepository,
+                                   UnitJpaRepository unitRepository,
+                                   UserAssignmentJpaRepository assignmentRepository,
+                                   UserNotificationSettingsJpaRepository notificationSettingsRepository,
+                                   DeviceJpaRepository deviceRepository,
+                                   DeviceCatalogJpaRepository deviceCatalogRepository) {
+        this.userRepository = userRepository;
+        this.unitRepository = unitRepository;
+        this.assignmentRepository = assignmentRepository;
+        this.notificationSettingsRepository = notificationSettingsRepository;
+        this.deviceRepository = deviceRepository;
+        this.deviceCatalogRepository = deviceCatalogRepository;
+    }
+
+    /**
+     * Возвращает список записей (до 10), ссылающихся на удаляемую,
+     * или {@code null}, если определить их невозможно.
+     */
+    public List<ReferenceDTO> resolve(DataIntegrityViolationException e) {
+        try {
+            PSQLException psqlException = findPsqlException(e);
+            if (psqlException == null) {
+                return null;
+            }
+            ServerErrorMessage serverError = psqlException.getServerErrorMessage();
+            if (serverError == null || serverError.getConstraint() == null || serverError.getDetail() == null) {
+                return null;
+            }
+            Long deletedId = parseDeletedId(serverError.getDetail());
+            if (deletedId == null) {
+                return null;
+            }
+            String constraint = serverError.getConstraint().toLowerCase(Locale.ROOT);
+            return switch (constraint) {
+                case FK_USERS_ON_ROLE -> userRepository.findTop10ByRole_IdOrderByIdAsc(deletedId).stream()
+                        .map(this::toUserReference)
+                        .toList();
+                case FK_UNITS_ON_WORKSHOP -> unitRepository.findTop10ByWorkshop_IdOrderByIdAsc(deletedId).stream()
+                        .map(this::toUnitReference)
+                        .toList();
+                case FK_USER_UNIT_ASSIGNMENTS_ON_USER ->
+                        assignmentRepository.findTop10ByUser_IdOrderByIdAsc(deletedId).stream()
+                                .map(this::toAssignmentReference)
+                                .toList();
+                case FK_USER_UNIT_ASSIGNMENTS_ON_UNIT ->
+                        assignmentRepository.findTop10ByUnit_IdOrderByIdAsc(deletedId).stream()
+                                .map(this::toAssignmentReference)
+                                .toList();
+                case FK_USER_NOTIFICATION_SETTINGS_ON_USER ->
+                        notificationSettingsRepository.findTop10ByUser_IdOrderByIdAsc(deletedId).stream()
+                                .map(this::toNotificationSettingsReference)
+                                .toList();
+                case FK_USER_NOTIFICATION_SETTINGS_ON_UNIT ->
+                        notificationSettingsRepository.findTop10ByUnit_IdOrderByIdAsc(deletedId).stream()
+                                .map(this::toNotificationSettingsReference)
+                                .toList();
+                case FK_DEVICE_CATALOG_ON_TYPE ->
+                        deviceCatalogRepository.findTop10ByType_IdOrderByIdAsc(deletedId).stream()
+                                .map(this::toDeviceCatalogReference)
+                                .toList();
+                case FK_UNIT_DEVICES_ON_UNIT -> deviceRepository.findTop10ByUnit_IdOrderByIdAsc(deletedId).stream()
+                        .map(this::toDeviceReference)
+                        .toList();
+                case FK_UNIT_DEVICES_ON_CATALOG -> deviceRepository.findTop10ByCatalog_IdOrderByIdAsc(deletedId).stream()
+                        .map(this::toDeviceReference)
+                        .toList();
+                default -> {
+                    log.debug("Unknown FK constraint '{}', references are not resolved", constraint);
+                    yield null;
+                }
+            };
+        } catch (Exception ex) {
+            log.warn("Failed to resolve delete references: {}", ex.getMessage(), ex);
+            return null;
+        }
+    }
+
+    private PSQLException findPsqlException(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof PSQLException psqlException) {
+                return psqlException;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    private Long parseDeletedId(String detail) {
+        Matcher matcher = DETAIL_KEY_PATTERN.matcher(detail);
+        if (!matcher.find()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(matcher.group(2));
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private ReferenceDTO toUserReference(UserEntity user) {
+        return new ReferenceDTO(TYPE_USERS, LABEL_USERS, user.getId(), user.getFullName());
+    }
+
+    private ReferenceDTO toUnitReference(UnitEntity unit) {
+        return new ReferenceDTO(TYPE_UNITS, LABEL_UNITS, unit.getId(), unit.getName());
+    }
+
+    private ReferenceDTO toDeviceCatalogReference(DeviceCatalogEntity catalog) {
+        return new ReferenceDTO(TYPE_DEVICE_CATALOG, LABEL_DEVICE_CATALOG, catalog.getId(), catalog.getName());
+    }
+
+    private ReferenceDTO toAssignmentReference(UserAssignmentEntity assignment) {
+        return new ReferenceDTO(TYPE_USER_ASSIGNMENTS, LABEL_USER_ASSIGNMENTS,
+                assignment.getId(), userUnitName(assignment.getUser(), assignment.getUnit()));
+    }
+
+    private ReferenceDTO toNotificationSettingsReference(UserNotificationSettingsEntity settings) {
+        return new ReferenceDTO(TYPE_USER_NOTIFICATION_SETTINGS, LABEL_USER_NOTIFICATION_SETTINGS,
+                settings.getId(), userUnitName(settings.getUser(), settings.getUnit()));
+    }
+
+    private ReferenceDTO toDeviceReference(DeviceEntity device) {
+        String unitName = device.getUnit() != null ? device.getUnit().getName() : "?";
+        String catalogName = device.getCatalog() != null ? device.getCatalog().getName() : "?";
+        return new ReferenceDTO(TYPE_UNIT_DEVICES, LABEL_UNIT_DEVICES,
+                device.getId(), unitName + " — " + catalogName);
+    }
+
+    private String userUnitName(UserEntity user, UnitEntity unit) {
+        String userName = user != null ? user.getFullName() : "?";
+        String unitName = unit != null ? unit.getName() : "?";
+        return userName + " — " + unitName;
+    }
+}

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package dev.savushkin.scada.mobile.backend.exception;
 
 import dev.savushkin.scada.mobile.backend.api.dto.ErrorResponseDTO;
+import dev.savushkin.scada.mobile.backend.api.dto.ReferenceDTO;
 import dev.savushkin.scada.mobile.backend.services.NotificationService.NotificationAccessDeniedException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -29,6 +30,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import java.io.IOException;
 import java.net.SocketException;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -57,6 +59,12 @@ public class GlobalExceptionHandler {
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
         private static final String INTERNAL_ERROR_MESSAGE = "Внутренняя ошибка сервера";
+
+        private final DeleteReferenceResolver deleteReferenceResolver;
+
+        public GlobalExceptionHandler(DeleteReferenceResolver deleteReferenceResolver) {
+                this.deleteReferenceResolver = deleteReferenceResolver;
+        }
 
         private @NonNull String extractPath(@NonNull WebRequest request) {
                 return request.getDescription(false).replace("uri=", "");
@@ -356,7 +364,8 @@ public class GlobalExceptionHandler {
      * <p>
      * Различает две типичные ситуации:
      * <ul>
-     *   <li>нарушение внешнего ключа (23503) — запись используется другими объектами;</li>
+     *   <li>нарушение внешнего ключа (23503) — запись используется другими объектами;
+     *       в ответ включается список ссылающихся записей (references), если его удалось определить;</li>
      *   <li>нарушение уникальности (23505) — запись с такими значениями уже существует.</li>
      * </ul>
      * Возвращает HTTP 409 (Conflict) с человекочитаемым сообщением.
@@ -367,10 +376,18 @@ public class GlobalExceptionHandler {
             @NonNull WebRequest request
     ) {
         log.warn("Data integrity violation: {}", e.getMessage());
-        String message = isForeignKeyViolation(e)
-                ? "Невозможно удалить запись, так как она используется другими объектами системы"
-                : "Запись с такими значениями уже существует";
-        return buildErrorResponse(HttpStatus.CONFLICT, message, request);
+        if (isForeignKeyViolation(e)) {
+            List<ReferenceDTO> references = deleteReferenceResolver.resolve(e);
+            ErrorResponseDTO error = new ErrorResponseDTO(
+                    HttpStatus.CONFLICT.value(),
+                    "Невозможно удалить запись, так как она используется другими объектами системы",
+                    extractPath(request),
+                    null,
+                    references
+            );
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+        }
+        return buildErrorResponse(HttpStatus.CONFLICT, "Запись с такими значениями уже существует", request);
     }
 
     private boolean isForeignKeyViolation(@NonNull DataIntegrityViolationException e) {

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/DeviceCatalogJpaRepository.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/DeviceCatalogJpaRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import org.jspecify.annotations.NonNull;
+import org.springframework.data.rest.core.annotation.RestResource;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DeviceCatalogJpaRepository extends JpaRepository<DeviceCatalogEntity, Long>, JpaSpecificationExecutor<DeviceCatalogEntity> {
@@ -13,4 +15,7 @@ public interface DeviceCatalogJpaRepository extends JpaRepository<DeviceCatalogE
     @NonNull Optional<DeviceCatalogEntity> findByCode(@NonNull String code);
 
     @NonNull Optional<DeviceCatalogEntity> findByName(@NonNull String name);
+
+    @RestResource(exported = false)
+    @NonNull List<DeviceCatalogEntity> findTop10ByType_IdOrderByIdAsc(@NonNull Long typeId);
 }

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/DeviceJpaRepository.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/DeviceJpaRepository.java
@@ -15,6 +15,12 @@ public interface DeviceJpaRepository extends JpaRepository<DeviceEntity, Long>, 
     List<DeviceEntity> findByUnit_Id(Long unitId);
 
     @RestResource(exported = false)
+    List<DeviceEntity> findTop10ByUnit_IdOrderByIdAsc(Long unitId);
+
+    @RestResource(exported = false)
+    List<DeviceEntity> findTop10ByCatalog_IdOrderByIdAsc(Long catalogId);
+
+    @RestResource(exported = false)
     void deleteByUnit_Id(Long unitId);
 
     @RestResource(exported = false)

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UnitJpaRepository.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UnitJpaRepository.java
@@ -89,4 +89,7 @@ public interface UnitJpaRepository extends JpaRepository<UnitEntity, Long>, JpaS
 
     @RestResource(exported = false)
     long countByWorkshop_Id(@NonNull @Param("workshopId") Long workshopId);
+
+    @RestResource(exported = false)
+    @NonNull List<UnitEntity> findTop10ByWorkshop_IdOrderByIdAsc(@NonNull Long workshopId);
 }

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserAssignmentJpaRepository.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserAssignmentJpaRepository.java
@@ -66,4 +66,7 @@ public interface UserAssignmentJpaRepository extends JpaRepository<UserAssignmen
 
     @RestResource(exported = false)
     List<UserAssignmentEntity> findTop10ByUnit_IdOrderByIdAsc(Long unitId);
+
+    @RestResource(exported = false)
+    List<UserAssignmentEntity> findTop10ByUnit_IdAndActiveTrueOrderByIdAsc(Long unitId);
 }

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserAssignmentJpaRepository.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserAssignmentJpaRepository.java
@@ -60,4 +60,10 @@ public interface UserAssignmentJpaRepository extends JpaRepository<UserAssignmen
 
     @RestResource(exported = false)
     Optional<UserAssignmentEntity> findByUnit_IdAndActiveTrue(Long unitId);
+
+    @RestResource(exported = false)
+    List<UserAssignmentEntity> findTop10ByUser_IdOrderByIdAsc(Long userId);
+
+    @RestResource(exported = false)
+    List<UserAssignmentEntity> findTop10ByUnit_IdOrderByIdAsc(Long unitId);
 }

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserJpaRepository.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserJpaRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.data.rest.core.annotation.RestResource;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -16,6 +17,9 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long>, JpaS
 
     @RestResource(exported = false)
     @NonNull Optional<UserEntity> findByCode(@NonNull String code);
+
+    @RestResource(exported = false)
+    @NonNull List<UserEntity> findTop10ByRole_IdOrderByIdAsc(@NonNull Long roleId);
 
     @Query("""
             select u

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserNotificationSettingsJpaRepository.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/integration/database/repository/UserNotificationSettingsJpaRepository.java
@@ -54,4 +54,10 @@ public interface UserNotificationSettingsJpaRepository extends JpaRepository<Use
 
     @RestResource(exported = false)
     void deleteByUnit_Id(Long unitId);
+
+    @RestResource(exported = false)
+    @NonNull List<UserNotificationSettingsEntity> findTop10ByUser_IdOrderByIdAsc(Long userId);
+
+    @RestResource(exported = false)
+    @NonNull List<UserNotificationSettingsEntity> findTop10ByUnit_IdOrderByIdAsc(Long unitId);
 }

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/services/EmployeeAccessService.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/services/EmployeeAccessService.java
@@ -1,7 +1,9 @@
 package dev.savushkin.scada.mobile.backend.services;
 
+import dev.savushkin.scada.mobile.backend.config.AdminBootstrapConfig;
 import dev.savushkin.scada.mobile.backend.domain.auth.EmployeeCredentialsGenerator;
 import dev.savushkin.scada.mobile.backend.domain.model.UserAssignmentsChangedEvent;
+import dev.savushkin.scada.mobile.backend.exception.UnitAssignmentConflictException;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.RoleEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UserEntity;
 import dev.savushkin.scada.mobile.backend.infrastructure.integration.database.entity.UserAssignmentEntity;
@@ -124,6 +126,14 @@ public class EmployeeAccessService {
         }
 
         Set<Long> uniqueUnitIds = new HashSet<>(unitIds);
+
+        // Пользователь с ролью «Админ» не должен иметь закреплённых автоматов
+        RoleEntity userRole = user.getRole();
+        if (userRole != null && AdminBootstrapConfig.ADMIN_ROLE_NAME.equals(userRole.getName())
+                && !uniqueUnitIds.isEmpty()) {
+            throw new UnitAssignmentConflictException("unitIds",
+                    "Нельзя закреплять автоматы за пользователем с ролью «Админ»");
+        }
 
         for (Long unitId : uniqueUnitIds) {
             assignmentRepository.findByUnit_IdAndActiveTrue(unitId).ifPresent(existing -> {

--- a/frontend/src/admin/components/UserNotificationSettingsEditor.tsx
+++ b/frontend/src/admin/components/UserNotificationSettingsEditor.tsx
@@ -221,8 +221,8 @@ export function UserNotificationSettingsEditor({ userId }: UserNotificationSetti
                 <span className="text-sm font-medium text-[#1a1c1e]">Выбрать всё</span>
               </div>
 
-              <div className="flex-1 min-h-0 overflow-auto rounded-[12px] border border-[#e8eaed] p-3">
-                <div className="hidden max-h-[280px] overflow-y-auto lg:block">
+              <div className="flex min-h-0 flex-1 flex-col rounded-[12px] border border-[#e8eaed] p-3">
+                <div className="hidden min-h-0 flex-1 overflow-y-auto lg:block">
                   <table className="w-full border-collapse">
                     <thead className="sticky top-0 z-10 bg-white">
                       <tr className="border-b border-[#f0f0f0]">
@@ -281,7 +281,7 @@ export function UserNotificationSettingsEditor({ userId }: UserNotificationSetti
                   </table>
                 </div>
 
-                <div className="flex flex-col gap-2 lg:hidden">
+                <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto lg:hidden">
                   {rows.map((row) => {
                     const settingId = row.setting?.id;
                     return (

--- a/frontend/src/admin/components/UserNotificationSettingsEditor.tsx
+++ b/frontend/src/admin/components/UserNotificationSettingsEditor.tsx
@@ -182,7 +182,7 @@ export function UserNotificationSettingsEditor({ userId }: UserNotificationSetti
   }
 
   return (
-    <div className="flex flex-1 flex-col min-h-0">
+    <div className="m-1 flex flex-1 flex-col min-h-0 lg:m-2">
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
@@ -200,42 +200,42 @@ export function UserNotificationSettingsEditor({ userId }: UserNotificationSetti
           expanded ? 'max-h-[2000px] flex-1 opacity-100' : 'max-h-0 opacity-0'
         }`}
       >
-        <div className="flex h-full min-h-0 flex-col pt-4">
+        <div className="flex h-full min-h-0 flex-col pt-3">
           {rows.length === 0 ? (
             <p className="py-2 text-sm text-[#74777f]">Нет доступных автоматов</p>
           ) : (
             <>
-              <div className="mb-3 flex items-center gap-3">
+              <div className="mb-2 flex items-center gap-2">
                 <button
                   type="button"
                   onClick={handleToggleAll}
                   aria-pressed={allSelected}
-                  className={`flex h-6 w-6 items-center justify-center rounded-[8px] border transition-colors ${
+                  className={`flex h-3 w-3 items-center justify-center rounded-[4px] border transition-colors ${
                     allSelected
                       ? 'border-[#4285f4] bg-[#4285f4] text-white'
                       : 'border-[#e8eaed] bg-white text-transparent hover:border-[#c4c7cc]'
                   }`}
                 >
-                  <IconCheck size={14} />
+                  <IconCheck size={8} />
                 </button>
                 <span className="text-sm font-medium text-[#1a1c1e]">Выбрать всё</span>
               </div>
 
-              <div className="flex-1 min-h-0 overflow-auto">
-                <div className="hidden lg:block">
+              <div className="flex-1 min-h-0 overflow-auto rounded-[12px] border border-[#e8eaed] p-3">
+                <div className="hidden max-h-[280px] overflow-y-auto lg:block">
                   <table className="w-full border-collapse">
                     <thead className="sticky top-0 z-10 bg-white">
                       <tr className="border-b border-[#f0f0f0]">
-                        <th className="pb-3 text-left text-xs font-semibold uppercase tracking-[0.05em] text-[#74777f]">
+                        <th className="pb-2 text-left text-xs font-semibold uppercase tracking-[0.05em] text-[#74777f]">
                           Автомат
                         </th>
-                        <th className="pb-3 text-left text-xs font-semibold uppercase tracking-[0.05em] text-[#74777f]">
+                        <th className="pb-2 text-left text-xs font-semibold uppercase tracking-[0.05em] text-[#74777f]">
                           Тех. сбои
                         </th>
-                        <th className="pb-3 text-left text-xs font-semibold uppercase tracking-[0.05em] text-[#74777f]">
+                        <th className="pb-2 text-left text-xs font-semibold uppercase tracking-[0.05em] text-[#74777f]">
                           Вызов
                         </th>
-                        <th className="pb-3" />
+                        <th className="pb-2" />
                       </tr>
                     </thead>
                     <tbody>
@@ -244,12 +244,12 @@ export function UserNotificationSettingsEditor({ userId }: UserNotificationSetti
                         return (
                           <tr
                             key={row.unitId}
-                            className="border-b border-[#f0f0f0] last:border-b-0 even:bg-[#f8f9fa]"
+                            className="border-b border-[#f0f0f0] last:border-b-0 even:bg-[#edf0f4]"
                           >
-                            <td className="py-3 pr-4 text-sm font-medium text-[#1a1c1e]">
+                            <td className="py-1.5 pr-4 text-sm font-medium text-[#1a1c1e]">
                               {row.unitName}
                             </td>
-                            <td className="py-3 pr-4">
+                            <td className="py-1.5 pr-4">
                               <CheckButton
                                 checked={row.incidentNotificationsEnabled}
                                 onChange={() =>
@@ -257,7 +257,7 @@ export function UserNotificationSettingsEditor({ userId }: UserNotificationSetti
                                 }
                               />
                             </td>
-                            <td className="py-3 pr-4">
+                            <td className="py-1.5 pr-4">
                               <CheckButton
                                 checked={row.androidCallNotificationsEnabled}
                                 onChange={() =>
@@ -265,7 +265,7 @@ export function UserNotificationSettingsEditor({ userId }: UserNotificationSetti
                                 }
                               />
                             </td>
-                            <td className="py-3 text-right">
+                            <td className="py-1.5 text-right">
                               <RowActionsMenu
                                 isActive={row.active}
                                 onToggleActive={() => handleToggleActive(row)}
@@ -281,12 +281,15 @@ export function UserNotificationSettingsEditor({ userId }: UserNotificationSetti
                   </table>
                 </div>
 
-                <div className="flex flex-col gap-3 lg:hidden">
+                <div className="flex flex-col gap-2 lg:hidden">
                   {rows.map((row) => {
                     const settingId = row.setting?.id;
                     return (
-                      <div key={row.unitId} className="rounded-[16px] border border-[#f0f0f0] p-4">
-                        <div className="mb-3 flex items-center justify-between">
+                      <div
+                        key={row.unitId}
+                        className="rounded-[16px] border border-[#f0f0f0] p-2.5"
+                      >
+                        <div className="mb-2 flex items-center justify-between">
                           <span className="font-semibold text-[#1a1c1e]">{row.unitName}</span>
                           <RowActionsMenu
                             isActive={row.active}
@@ -327,13 +330,13 @@ function CheckButton({ checked, onChange }: { checked: boolean; onChange: () => 
       type="button"
       onClick={onChange}
       aria-pressed={checked}
-      className={`flex h-8 w-8 items-center justify-center rounded-[10px] border transition-colors ${
+      className={`flex h-4 w-4 items-center justify-center rounded-[5px] border transition-colors ${
         checked
           ? 'border-[#4285f4] bg-[#4285f4] text-white'
           : 'border-[#e8eaed] bg-white text-transparent hover:border-[#c4c7cc]'
       }`}
     >
-      <IconCheck size={18} />
+      <IconCheck size={10} />
     </button>
   );
 }
@@ -352,19 +355,19 @@ function CheckItem({
       type="button"
       onClick={onChange}
       aria-pressed={checked}
-      className={`flex flex-col items-center gap-1.5 rounded-[12px] py-2 transition-colors ${
+      className={`flex flex-col items-center gap-1.5 rounded-[12px] py-1.5 transition-colors ${
         checked ? 'bg-[#f0f7ff] text-[#4285f4]' : 'bg-[#f8f9fa] text-[#74777f]'
       }`}
     >
       <span className="text-[11px] font-medium uppercase tracking-wide">{label}</span>
       <div
-        className={`flex h-6 w-6 items-center justify-center rounded-[8px] border ${
+        className={`flex h-3 w-3 items-center justify-center rounded-[4px] border ${
           checked
             ? 'border-[#4285f4] bg-[#4285f4] text-white'
             : 'border-[#e8eaed] bg-white text-transparent'
         }`}
       >
-        <IconCheck size={14} />
+        <IconCheck size={8} />
       </div>
     </button>
   );

--- a/frontend/src/admin/resources/Users.tsx
+++ b/frontend/src/admin/resources/Users.tsx
@@ -276,6 +276,25 @@ function UserRightFields({
   onChange: (field: string, value: unknown) => void;
 }) {
   const [creatingUnit, setCreatingUnit] = useState(false);
+  const getRoleName = useNameMap('roles');
+  const isAdmin = getRoleName(record.roleId as number | undefined) === 'ADMIN';
+
+  // Для роли ADMIN закрепление автоматов запрещено (backend отклоняет 409).
+  // Очищаем unitIds, чтобы сохранение воспринималось как «снять привязки»,
+  // а не как попытку добавить автоматы.
+  useEffect(() => {
+    if (isAdmin && Array.isArray(record.unitIds) && record.unitIds.length > 0) {
+      onChange('unitIds', []);
+    }
+  }, [isAdmin, record.unitIds, onChange]);
+
+  if (isAdmin) {
+    return (
+      <div className="space-y-5">
+        <p className="text-sm text-[#74777f]">Закрепление автоматов недоступно для роли «Админ»</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-5">

--- a/frontend/src/admin/ui/AdminBreadcrumbs.tsx
+++ b/frontend/src/admin/ui/AdminBreadcrumbs.tsx
@@ -44,7 +44,7 @@ export function AdminBreadcrumbs() {
     const resourceLabel = resource ? (REFERENCE_LABELS[resource] ?? resource) : null;
 
     return (
-      <nav className="flex items-center gap-1.5 text-xs leading-none">
+      <nav className="flex items-center gap-1.5 text-sm leading-none">
         <button
           type="button"
           onClick={() => navigate('/admin/settings')}
@@ -52,7 +52,7 @@ export function AdminBreadcrumbs() {
         >
           Настройки
         </button>
-        <IconChevronRight size={14} className="text-[#b0b3b8]" />
+        <IconChevronRight size={16} className="text-[#b0b3b8]" />
         {resourceLabel ? (
           <button
             type="button"
@@ -66,7 +66,7 @@ export function AdminBreadcrumbs() {
         )}
         {resourceLabel && (
           <>
-            <IconChevronRight size={14} className="text-[#b0b3b8]" />
+            <IconChevronRight size={16} className="text-[#b0b3b8]" />
             {tail ? (
               <button
                 type="button"
@@ -82,7 +82,7 @@ export function AdminBreadcrumbs() {
         )}
         {tail && (
           <>
-            <IconChevronRight size={14} className="text-[#b0b3b8]" />
+            <IconChevronRight size={16} className="text-[#b0b3b8]" />
             <span className="font-medium leading-none text-[#1a1c1e]">
               {tail === 'create' ? 'Создание' : 'Редактирование'}
             </span>
@@ -101,7 +101,7 @@ export function AdminBreadcrumbs() {
     if (!backLabel) return null;
 
     return (
-      <nav className="flex items-center gap-1.5 text-xs leading-none">
+      <nav className="flex items-center gap-1.5 text-sm leading-none">
         <button
           type="button"
           onClick={() => navigate(`/admin/${resource}`)}

--- a/frontend/src/admin/ui/AdminDeleteButton.tsx
+++ b/frontend/src/admin/ui/AdminDeleteButton.tsx
@@ -3,21 +3,12 @@ import { useDelete, useNotify, useRefresh, useResourceContext } from 'react-admi
 import { PillButton } from './PillButton';
 import { ConfirmDialog } from './ConfirmDialog';
 import { IconTrash } from './icons';
+import { formatDeleteError } from './errorMessages';
 
 interface AdminDeleteButtonProps {
   record: { id: string | number };
   className?: string;
   size?: 'default' | 'small';
-}
-
-function getErrorMessage(error: unknown, fallback: string): string {
-  if (typeof error === 'string') return error || fallback;
-  if (error instanceof Error) return error.message || fallback;
-  if (error && typeof error === 'object' && 'message' in error) {
-    const message = (error as { message?: unknown }).message;
-    return typeof message === 'string' && message ? message : fallback;
-  }
-  return fallback;
 }
 
 export function AdminDeleteButton({
@@ -39,7 +30,7 @@ export function AdminDeleteButton({
         refresh();
       },
       onError: (error) => {
-        notify(getErrorMessage(error, 'Ошибка удаления'), {
+        notify(formatDeleteError(error), {
           type: 'error',
           autoHideDuration: null,
         });

--- a/frontend/src/admin/ui/AdminEditForm.tsx
+++ b/frontend/src/admin/ui/AdminEditForm.tsx
@@ -8,6 +8,7 @@ import { AdminPageHeader } from './AdminPageHeader';
 import { ActionMenu, type ActionMenuItem } from './ActionMenu';
 import { ResizablePanels } from './ResizablePanels';
 import { useFormKeyboardNavigation } from './useFormKeyboardNavigation';
+import { formatDeleteError, getErrorMessage } from './errorMessages';
 import { IconSave } from './icons';
 import type { ReactNode } from 'react';
 
@@ -45,16 +46,6 @@ function isRecordDirty(
 ): boolean {
   if (!original) return true;
   return Object.entries(current).some(([key, value]) => original[key] !== value);
-}
-
-function getErrorMessage(error: unknown, fallback: string): string {
-  if (typeof error === 'string') return error || fallback;
-  if (error instanceof Error) return error.message || fallback;
-  if (error && typeof error === 'object' && 'message' in error) {
-    const message = (error as { message?: unknown }).message;
-    return typeof message === 'string' && message ? message : fallback;
-  }
-  return fallback;
 }
 
 function getListPath(resource: string): string {
@@ -136,7 +127,7 @@ export function AdminEditForm({
           navigate(getListPath(resource ?? ''));
         },
         onError: (error) => {
-          notify(getErrorMessage(error, 'Ошибка удаления'), {
+          notify(formatDeleteError(error), {
             type: 'error',
             autoHideDuration: null,
           });

--- a/frontend/src/admin/ui/AdminListContainer.tsx
+++ b/frontend/src/admin/ui/AdminListContainer.tsx
@@ -65,7 +65,8 @@ export function AdminListContainer<T>({
         <AdminBreadcrumbs />
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <h1 className="text-xl font-bold text-[#1a1c1e]">{title}</h1>
-          {!filterFields && <div className="flex items-center gap-2">{actions}</div>}
+          <div className="hidden lg:flex lg:items-center lg:gap-2">{actions}</div>
+          {!filterFields && <div className="flex items-center gap-2 lg:hidden">{actions}</div>}
         </div>
         {filterFields && <FilterToolbar actions={actions} />}
       </div>

--- a/frontend/src/admin/ui/DesktopDataTable.tsx
+++ b/frontend/src/admin/ui/DesktopDataTable.tsx
@@ -69,7 +69,7 @@ export function DesktopDataTable<T>({
               return (
                 <tr
                   key={keyExtractor(record, index)}
-                  className={`group border-b border-[#f0f0f0] last:border-b-0 even:bg-[#f8f9fa] ${
+                  className={`group border-b border-[#f0f0f0] last:border-b-0 even:bg-[#edf0f4] ${
                     active
                       ? ''
                       : 'bg-[#f8f9fa] [&>td]:opacity-60 [&>td:first-child]:opacity-100 [&>td:last-child]:opacity-100'
@@ -78,7 +78,7 @@ export function DesktopDataTable<T>({
                   {allColumns.map((col) => (
                     <td
                       key={col.key}
-                      className={`py-3 pr-4 transition-colors duration-200 group-hover:bg-[#f0f7ff] first:rounded-l-[12px] last:rounded-r-[12px] ${col.className ?? ''}`}
+                      className={`py-3 pr-4 transition-colors duration-200 group-hover:bg-[#e2e5e9] first:rounded-l-[12px] last:rounded-r-[12px] ${col.className ?? ''}`}
                     >
                       {formatEmpty(col.render(record))}
                     </td>

--- a/frontend/src/admin/ui/FilterToolbar.tsx
+++ b/frontend/src/admin/ui/FilterToolbar.tsx
@@ -31,7 +31,7 @@ export function FilterToolbar({ actions }: { actions?: ReactNode }) {
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-wrap items-center gap-2">
-        <div className="relative flex-1 lg:w-80 lg:flex-none">
+        <div className="relative flex-1 lg:hidden">
           <IconSearch
             size={18}
             className="absolute left-3 top-1/2 -translate-y-1/2 text-[#74777f]"
@@ -48,7 +48,7 @@ export function FilterToolbar({ actions }: { actions?: ReactNode }) {
           type="button"
           onClick={() => setHintOpen((v) => !v)}
           title="Как искать"
-          className={`flex h-8 w-8 flex-none items-center justify-center rounded-full text-sm font-semibold transition-colors ${
+          className={`flex h-8 w-8 flex-none items-center justify-center rounded-full text-sm font-semibold transition-colors lg:hidden ${
             hintOpen ? 'bg-[#1a1c1e] text-white' : 'bg-white text-[#74777f] hover:bg-[#f8f9fa]'
           }`}
         >
@@ -68,7 +68,9 @@ export function FilterToolbar({ actions }: { actions?: ReactNode }) {
                   key={token}
                   tone="error"
                   label={`Некорректный фильтр: ${token}`}
-                  onRemove={() => ctx.setRawSearch(removeFieldToken(rawSearch, token.split(':')[0]))}
+                  onRemove={() =>
+                    ctx.setRawSearch(removeFieldToken(rawSearch, token.split(':')[0]))
+                  }
                 />
               ))}
             </ChipStripScroller>
@@ -82,7 +84,7 @@ export function FilterToolbar({ actions }: { actions?: ReactNode }) {
           </div>
         )}
         {actions && (
-          <div className="ml-auto flex flex-wrap items-center gap-2">{actions}</div>
+          <div className="ml-auto flex flex-wrap items-center gap-2 lg:hidden">{actions}</div>
         )}
       </div>
 
@@ -222,11 +224,13 @@ function FieldChip({
 
   return (
     <Chip
-      label={field?.chipLabel ?? (
-        <>
-          {label}: {display}
-        </>
-      )}
+      label={
+        field?.chipLabel ?? (
+          <>
+            {label}: {display}
+          </>
+        )
+      }
       onRemove={() => ctx.removeFieldFilter(fieldKey)}
     />
   );

--- a/frontend/src/admin/ui/SearchableSelect.tsx
+++ b/frontend/src/admin/ui/SearchableSelect.tsx
@@ -10,6 +10,10 @@ const DROPDOWN_FLIP_THRESHOLD = 260;
 /** Минимальная/максимальная высота десктопного дропдауна. */
 const DROPDOWN_MIN_HEIGHT = 140;
 const DROPDOWN_MAX_HEIGHT = 400;
+/** Отступ дропдауна от края viewport (чтобы список не упирался в край экрана). */
+const DROPDOWN_VIEWPORT_MARGIN = 16;
+/** Дропдаун не должен занимать больше этой доли высоты экрана. */
+const DROPDOWN_MAX_VIEWPORT_RATIO = 0.5;
 
 interface Choice {
   id: string | number;
@@ -110,15 +114,20 @@ export function SearchableSelect({
   };
 
   // Направление и высота дропдауна: если снизу мало места,
-  // а сверху больше — открываем вверх; высота ограничена доступным местом.
+  // а сверху больше — открываем вверх; высота ограничена доступным местом
+  // и долей высоты экрана, чтобы список не уходил за видимую область.
   const placement = useMemo(() => {
     if (!triggerRect) return null;
     const viewportHeight = window.innerHeight;
-    const spaceBelow = viewportHeight - triggerRect.bottom - DROPDOWN_GAP;
-    const spaceAbove = triggerRect.top - DROPDOWN_GAP;
+    const spaceBelow =
+      viewportHeight - triggerRect.bottom - DROPDOWN_GAP - DROPDOWN_VIEWPORT_MARGIN;
+    const spaceAbove = triggerRect.top - DROPDOWN_GAP - DROPDOWN_VIEWPORT_MARGIN;
     const openUp = spaceBelow < DROPDOWN_FLIP_THRESHOLD && spaceAbove > spaceBelow;
     const available = openUp ? spaceAbove : spaceBelow;
-    const maxHeight = Math.max(DROPDOWN_MIN_HEIGHT, Math.min(available, DROPDOWN_MAX_HEIGHT));
+    const maxHeight = Math.max(
+      DROPDOWN_MIN_HEIGHT,
+      Math.min(available, DROPDOWN_MAX_HEIGHT, viewportHeight * DROPDOWN_MAX_VIEWPORT_RATIO)
+    );
     return { openUp, maxHeight };
   }, [triggerRect]);
 

--- a/frontend/src/admin/ui/errorMessages.ts
+++ b/frontend/src/admin/ui/errorMessages.ts
@@ -1,0 +1,63 @@
+/**
+ * Общие хелперы для человекочитаемых сообщений об ошибках админки.
+ */
+
+/** Связанная запись, которую backend возвращает при FK-ошибке удаления (HTTP 409). */
+export interface DeleteReference {
+  type: string;
+  typeLabel: string;
+  id: number | string;
+  name: string;
+}
+
+export function getErrorMessage(error: unknown, fallback: string): string {
+  if (typeof error === 'string') return error || fallback;
+  if (error instanceof Error) return error.message || fallback;
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    return typeof message === 'string' && message ? message : fallback;
+  }
+  return fallback;
+}
+
+/**
+ * Сообщение об ошибке удаления. Если backend вернул `body.references`
+ * (FK-ограничение, HTTP 409), дополняет текст списком связанных записей,
+ * сгруппированным по типам:
+ * «…Связанные записи — Автоматы: «Розлив №2»; Сотрудники: «Иванов И.И.».»
+ */
+export function formatDeleteError(error: unknown, fallback = 'Ошибка удаления'): string {
+  const base = getErrorMessage(error, fallback);
+  const references = getDeleteReferences(error);
+  if (references.length === 0) return base;
+
+  const groups = new Map<string, string[]>();
+  for (const ref of references) {
+    const label = ref.typeLabel || ref.type;
+    const name = ref.name?.trim() ? `«${ref.name}»` : `#${ref.id}`;
+    const names = groups.get(label) ?? [];
+    names.push(name);
+    groups.set(label, names);
+  }
+
+  const list = [...groups.entries()]
+    .map(([label, names]) => `${label}: ${names.join(', ')}`)
+    .join('; ');
+  const baseWithDot = base.replace(/[\s.]+$/, '');
+  return `${baseWithDot}. Связанные записи — ${list}.`;
+}
+
+function getDeleteReferences(error: unknown): DeleteReference[] {
+  if (!error || typeof error !== 'object' || !('body' in error)) return [];
+  const body = (error as { body?: unknown }).body;
+  if (!body || typeof body !== 'object' || !('references' in body)) return [];
+  const references = (body as { references?: unknown }).references;
+  if (!Array.isArray(references)) return [];
+  return references.filter(
+    (ref): ref is DeleteReference =>
+      ref != null &&
+      typeof ref === 'object' &&
+      typeof (ref as DeleteReference).type === 'string' &&
+      typeof (ref as DeleteReference).typeLabel === 'string'
+  );
+}

--- a/frontend/src/admin/ui/useRowActions.ts
+++ b/frontend/src/admin/ui/useRowActions.ts
@@ -7,16 +7,7 @@ import {
   useRefresh,
 } from 'react-admin';
 import type { RaRecord } from 'react-admin';
-
-function getErrorMessage(error: unknown, fallback: string): string {
-  if (typeof error === 'string') return error || fallback;
-  if (error instanceof Error) return error.message || fallback;
-  if (error && typeof error === 'object' && 'message' in error) {
-    const message = (error as { message?: unknown }).message;
-    return typeof message === 'string' && message ? message : fallback;
-  }
-  return fallback;
-}
+import { formatDeleteError, getErrorMessage } from './errorMessages';
 
 interface RecordWithActive extends RaRecord {
   active?: boolean;
@@ -67,7 +58,7 @@ export function useRowActions() {
           notify('Удалено', { type: 'info' });
         },
         onError: (error) => {
-          notify(getErrorMessage(error, 'Ошибка удаления'), {
+          notify(formatDeleteError(error), {
             type: 'error',
             autoHideDuration: null,
           });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -46,7 +46,7 @@
     --clr-blue-light: #f0f7ff;
     --clr-border-soft: #e8eaed;
     /* Фон чётных строк в табличных списках (zebra) */
-    --clr-row-alt: #f8f9fa;
+    --clr-row-alt: #edf0f4;
 
     /*
       --app-height обновляется из JS (visualViewport / innerHeight).


### PR DESCRIPTION
## Что сделано

### #35 — Связанные записи при ошибке удаления (P1)
- **Backend**: при FK-ошибке удаления (SQLState 23503) `GlobalExceptionHandler` через новый `DeleteReferenceResolver` извлекает из `PSQLException` имя констрейнта и id записи, находит до 10 ссылающихся строк по соответствующим репозиториям и возвращает их в ответе 409: `references: [{ type, typeLabel, id, name }]` (новое поле в `ErrorResponseDTO`, `ReferenceDTO`). Маппинг покрывает констрейнты roles/workshops/device-types/device-catalog/user-assignments/notification-settings/unit-devices.
- **Frontend**: новый хелпер `formatDeleteError` (`admin/ui/errorMessages.ts`) дополняет тост ошибки списком: «…Связанные записи — Сотрудники: «Test User», «Second User».» Применён во всех точках удаления (`useRowActions`, `AdminEditForm`, `AdminDeleteButton`).

### #39 — Запрет прикрепления автоматов за админом
- **Backend**: валидация роли `ADMIN` во всех точках назначения — `AdminUserAssignmentController` (create/update), `AdminUserController.syncAssignments` (только новые привязки; снятие существующих разрешено), `EmployeeAccessService`. Ошибка — `UnitAssignmentConflictException` → 409 с `errors.unitIds`.
- **Frontend**: в карточке сотрудника с ролью «Админ» селект автоматов скрыт (подсказка «Закрепление автоматов недоступно для роли «Админ»»), `unitIds` очищается перед сохранением.

### #41 — Компактный блок настроек уведомлений
- Чекбоксы уменьшены вдвое (24→12px, кнопки 32→16px), список автоматов сжат по вертикали (отступы, `max-h` со скроллом), добавлены отступы/рамка для «воздуха» от правой карточки.

### Доп. UI
- Контрастная зебра во всех таблицах (`#f8f9fa` → `#edf0f4`, включая `--clr-row-alt`).
- Hover строки таблицы — серый `#e2e5e9` вместо синего `#f0f7ff`.
- Хлебные крошки увеличены (`text-xs` → `text-sm`).
- Поиск скрыт на десктопе (на мобильном — во всю ширину); кнопка «Создать» на десктопе всегда напротив заголовка страницы.

## Проверка
- `npm run build` (frontend) и `gradlew compileJava` + `gradlew test` (backend, 57 тестов) — зелёные.
- Ручная проверка через Playwright (desktop + mobile): список сотрудников, карточки ADMIN/Master, удаление роли «Master» → 409 с списком связанных сотрудников в тосте; backend-валидация #39 проверена через API (409).

Closes #35
Closes #39
Closes #41