### PR TITLE
feat(admin): профиль администратора и вкладка «Справочники» в шапке (#38, #49)

### DIFF
--- a/frontend/src/admin/AdminApp.tsx
+++ b/frontend/src/admin/AdminApp.tsx
@@ -16,6 +16,7 @@ import { NotificationList } from './resources/Notifications';
 import { NotificationSettingsEdit } from './resources/NotificationSettings';
 import { SettingsPage } from './resources/Settings';
 import { ReferenceHubPage } from './resources/ReferenceHub';
+import { AdminProfilePage } from './resources/AdminProfile';
 import {
   ReferenceListPage,
   ReferenceEditPage,
@@ -108,6 +109,7 @@ export function AdminApp() {
         <Route path="/settings/references/:resource" element={<ReferenceListPage />} />
         <Route path="/settings/references/:resource/create" element={<ReferenceCreatePage />} />
         <Route path="/settings/references/:resource/:id" element={<ReferenceEditPage />} />
+        <Route path="/profile" element={<AdminProfilePage />} />
       </CustomRoutes>
     </Admin>
   );

--- a/frontend/src/admin/resources/AdminProfile.tsx
+++ b/frontend/src/admin/resources/AdminProfile.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchUserProfile } from '../../api/profile';
+import { logoutUser } from '../../api/auth';
+import { useAuth } from '../../context/AuthContext';
+import { useAsyncFetch } from '../../hooks/useAsyncFetch';
+import { getErrorBodyMessage } from '../../errors/AppError';
+import type { UserProfile } from '../../types';
+import { SkeletonBlock } from '../../components/skeleton/SkeletonBlock';
+
+const ADMIN_PROFILE_COPY = Object.freeze({
+  title: 'Профиль',
+  roleLabel: 'Роль',
+  workerCodeLabel: 'Табельный номер',
+  monitoringButton: 'Мониторинг',
+  logoutButtonAriaLabel: 'Выйти из аккаунта',
+  logoutOverlayTitle: 'Выйти из аккаунта?',
+  logoutOverlayMessage: 'Для повторного входа потребуется ввести код и пароль работника',
+  logoutOverlayCancel: 'Отмена',
+  logoutOverlayConfirm: 'Выйти',
+});
+
+function getInitials(fullName: string): string {
+  const parts = fullName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '-';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+}
+
+/**
+ * Профиль администратора внутри админ-панели (/admin/profile).
+ * В отличие от профиля мониторинга (/profile) рендерится под шапкой
+ * администрирования и не содержит блоков «Закрепленное оборудование»
+ * и «Настроить уведомления» — они относятся к сотрудникам мониторинга.
+ */
+export function AdminProfilePage() {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  const profileFetch = useAsyncFetch<UserProfile>((signal) => fetchUserProfile(signal), [], {
+    source: 'profile',
+  });
+
+  const [logoutOpen, setLogoutOpen] = useState(false);
+
+  const handleLogoutClick = useCallback(() => {
+    setLogoutOpen(true);
+  }, []);
+
+  const handleLogoutCancel = useCallback(() => {
+    setLogoutOpen(false);
+  }, []);
+
+  const handleLogoutConfirm = useCallback(async () => {
+    setLogoutOpen(false);
+    await logoutUser();
+    logout();
+    navigate('/login', { replace: true });
+    // Принудительно перезагружаем страницу для полной очистки состояния
+    window.location.reload();
+  }, [logout, navigate]);
+
+  const profileInitials = useMemo(() => {
+    if (!profileFetch.data?.fullName) return '—';
+    return getInitials(profileFetch.data.fullName);
+  }, [profileFetch.data?.fullName]);
+
+  const profileError = profileFetch.error;
+  const isProfileLoading = profileFetch.status === 'loading';
+
+  return (
+    <div className="p-3 lg:p-4">
+      <div className="mb-3 lg:mb-4">
+        <h1 className="text-xl font-bold text-[#1a1c1e]">{ADMIN_PROFILE_COPY.title}</h1>
+      </div>
+
+      <div className="mx-auto flex w-full max-w-[520px] flex-col gap-4">
+        {isProfileLoading ? (
+          <div className="flex w-full flex-col gap-4" aria-hidden="true">
+            <div className="flex flex-col items-center gap-3">
+              <SkeletonBlock height="64px" width="64px" borderRadius="14px" />
+              <div className="text-center">
+                <SkeletonBlock height="22px" width="220px" borderRadius="6px" />
+                <div className="mt-2 inline-flex items-center gap-2">
+                  <SkeletonBlock height="18px" width="120px" borderRadius="999px" />
+                </div>
+              </div>
+            </div>
+            <div className="rounded-[22px] border border-white/70 bg-white/90 px-4 py-4 shadow-[0_14px_40px_rgba(20,30,50,0.06)]">
+              <SkeletonBlock height="12px" width="140px" borderRadius="6px" />
+              <div className="mt-2">
+                <SkeletonBlock height="18px" width="60%" borderRadius="6px" />
+              </div>
+            </div>
+            <div>
+              <SkeletonBlock height="44px" width="100%" borderRadius="12px" />
+            </div>
+          </div>
+        ) : profileError ? (
+          <p className="py-10 text-center text-sm text-[#74777F]">
+            {getErrorBodyMessage(profileError)}
+          </p>
+        ) : (
+          <>
+            <div className="flex flex-col items-center gap-3">
+              <div className="flex h-16 w-16 items-center justify-center rounded-[20px] bg-[#0b5da4] text-xl font-semibold text-white shadow-sm">
+                {profileInitials}
+              </div>
+              <div className="text-center">
+                <h2 className="text-lg font-semibold text-[#1A1C1E]">
+                  {profileFetch.data?.fullName ?? '—'}
+                </h2>
+                <div className="mt-2 inline-flex items-center gap-2 rounded-full bg-[#eaf2ff] px-3 py-1 text-xs font-semibold text-[#1c4f8a]">
+                  <span>{ADMIN_PROFILE_COPY.roleLabel}:</span>
+                  <span>{profileFetch.data?.role ?? '—'}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-[22px] border border-white/70 bg-white/90 px-4 py-4 shadow-[0_14px_40px_rgba(20,30,50,0.06)]">
+              <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-[#8a8f98]">
+                {ADMIN_PROFILE_COPY.workerCodeLabel}
+              </p>
+              <p className="mt-2 text-base font-semibold text-[#1A1C1E]">
+                {profileFetch.data?.workerCode ?? '—'}
+              </p>
+            </div>
+
+            <div className="mt-2 flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => navigate('/')}
+                className="flex flex-1 items-center justify-center gap-2 rounded-[18px] bg-[#0b5da4] px-4 py-3 text-sm font-semibold text-white shadow-[0_10px_26px_rgba(11,93,164,0.32)]"
+              >
+                <span>{ADMIN_PROFILE_COPY.monitoringButton}</span>
+              </button>
+              <button
+                type="button"
+                onClick={handleLogoutClick}
+                aria-label={ADMIN_PROFILE_COPY.logoutButtonAriaLabel}
+                className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#EA4335] text-white shadow-[0_0_10px_rgba(234,67,53,0.18)] transition-all duration-200 ease-in-out active:scale-[0.98]"
+              >
+                <img
+                  src="/assets/logout.svg"
+                  alt=""
+                  aria-hidden="true"
+                  className="h-5 w-5 invert"
+                />
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      {logoutOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-6 backdrop-blur-[2px]"
+          onClick={handleLogoutCancel}
+          role="presentation"
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={ADMIN_PROFILE_COPY.logoutOverlayTitle}
+            className="w-full max-w-[360px] rounded-[26px] bg-[#f8fafc] p-6 shadow-[0_30px_80px_rgba(17,24,39,0.25)]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-base font-semibold text-[#1A1C1E]">
+              {ADMIN_PROFILE_COPY.logoutOverlayTitle}
+            </h3>
+            <p className="mt-2 text-sm text-[#5F6368]">{ADMIN_PROFILE_COPY.logoutOverlayMessage}</p>
+            <div className="mt-6 flex items-center justify-end gap-3">
+              <button
+                type="button"
+                onClick={handleLogoutCancel}
+                className="rounded-2xl border border-[#e2e8f0] bg-white px-5 py-2.5 text-sm font-semibold text-[#1A1C1E] transition active:scale-[0.98]"
+              >
+                {ADMIN_PROFILE_COPY.logoutOverlayCancel}
+              </button>
+              <button
+                type="button"
+                onClick={handleLogoutConfirm}
+                className="rounded-2xl bg-[#EA4335] px-5 py-2.5 text-sm font-semibold text-white shadow-[0_4px_14px_rgba(234,67,53,0.35)] transition active:scale-[0.98]"
+              >
+                {ADMIN_PROFILE_COPY.logoutOverlayConfirm}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/admin/ui/AdminBottomSheetMenu.tsx
+++ b/frontend/src/admin/ui/AdminBottomSheetMenu.tsx
@@ -66,19 +66,19 @@ export function AdminBottomSheetMenu() {
           <button
             type="button"
             onClick={() => {
-              navigate('/profile', { state: { from: { pathname: location.pathname } } });
+              navigate('/admin/profile');
               closeMenu();
             }}
             className={
               'flex items-center gap-3 rounded-[12px] px-4 py-3.5 text-[15px] font-medium transition-colors ' +
-              (location.pathname.startsWith('/profile')
+              (location.pathname.startsWith('/admin/profile')
                 ? 'bg-[#f0f7ff] text-[#4285f4] '
                 : 'text-[#1a1c1e] hover:bg-[#f8f9fa] ')
             }
           >
             <span
               className={
-                location.pathname.startsWith('/profile') ? 'text-[#4285f4]' : 'text-[#74777f]'
+                location.pathname.startsWith('/admin/profile') ? 'text-[#4285f4]' : 'text-[#74777f]'
               }
             >
               <IconUserTie size={20} />

--- a/frontend/src/admin/ui/AdminBreadcrumbs.tsx
+++ b/frontend/src/admin/ui/AdminBreadcrumbs.tsx
@@ -29,7 +29,9 @@ export function AdminBreadcrumbs() {
     pathname === '/admin/users' ||
     pathname === '/admin/units' ||
     pathname === '/admin/notifications' ||
-    pathname === '/admin/settings'
+    pathname === '/admin/settings' ||
+    pathname === '/admin/settings/references' ||
+    pathname === '/admin/profile'
   ) {
     return null;
   }
@@ -45,14 +47,6 @@ export function AdminBreadcrumbs() {
 
     return (
       <nav className="flex items-center gap-1.5 text-sm leading-none">
-        <button
-          type="button"
-          onClick={() => navigate('/admin/settings')}
-          className="leading-none text-[#74777f] transition-colors hover:text-[#1a1c1e]"
-        >
-          Настройки
-        </button>
-        <IconChevronRight size={16} className="text-[#b0b3b8]" />
         {resourceLabel ? (
           <button
             type="button"

--- a/frontend/src/admin/ui/AdminHeader.tsx
+++ b/frontend/src/admin/ui/AdminHeader.tsx
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAdminNotificationsCount } from './AdminNotificationsContext';
-import { IconSettings, IconNotifications, IconUserTie } from './icons';
+import { IconBooks, IconSettings, IconNotifications, IconUserTie } from './icons';
 
 const operationalItems = [
   { name: 'users', label: 'Сотрудники' },
@@ -49,12 +49,24 @@ export function AdminHeader() {
       </div>
 
       <div className="flex items-center gap-2">
+        {/* Иконка «Настройки» скрыта (issue #49): внутри раздела пока только
+            справочники, которые вынесены в отдельную иконку ниже. Кнопка и
+            маршрут /admin/settings сохранены на будущее. */}
+        <div className="hidden">
+          <HeaderIconButton
+            active={location.pathname.startsWith('/admin/settings')}
+            onClick={() => navigate('/admin/settings')}
+            ariaLabel="Настройки"
+          >
+            <IconSettings size={20} />
+          </HeaderIconButton>
+        </div>
         <HeaderIconButton
-          active={location.pathname.startsWith('/admin/settings')}
-          onClick={() => navigate('/admin/settings')}
-          ariaLabel="Настройки"
+          active={location.pathname.startsWith('/admin/settings/references')}
+          onClick={() => navigate('/admin/settings/references')}
+          ariaLabel="Справочники"
         >
-          <IconSettings size={20} />
+          <IconBooks size={20} />
         </HeaderIconButton>
         <HeaderIconButton
           active={location.pathname.startsWith('/admin/notifications')}
@@ -65,8 +77,8 @@ export function AdminHeader() {
           <IconNotifications size={20} />
         </HeaderIconButton>
         <HeaderIconButton
-          active={location.pathname.startsWith('/profile')}
-          onClick={() => navigate('/profile', { state: { from: { pathname: location.pathname } } })}
+          active={location.pathname.startsWith('/admin/profile')}
+          onClick={() => navigate('/admin/profile')}
           ariaLabel="Профиль"
         >
           <IconUserTie size={20} />

--- a/frontend/src/admin/ui/AdminMenuConfig.tsx
+++ b/frontend/src/admin/ui/AdminMenuConfig.tsx
@@ -1,5 +1,5 @@
 import {
-  IconSettings,
+  IconBooks,
   IconNotifications,
   IconUnits,
   IconUserTie as IconUsers,
@@ -15,9 +15,19 @@ export interface AdminMenuItem {
   icon: React.ReactNode;
 }
 
-/** Пункты бокового/мобильного меню админ-панели. */
+/**
+ * Пункты бокового/мобильного меню админ-панели.
+ * Раздел «Настройки» (маршрут /admin/settings) временно скрыт из навигации
+ * (issue #49): внутри него пока только справочники, которые вынесены
+ * в отдельный пункт. Вернуть пункт «Настройки», когда в разделе появится
+ * что-то кроме справочников.
+ */
 export const adminMenuItems: AdminMenuItem[] = [
-  { name: 'settings', label: 'Настройки', icon: <IconSettings size={20} /> },
+  {
+    name: 'settings/references',
+    label: 'Справочники',
+    icon: <IconBooks size={20} />,
+  },
   { name: 'notifications', label: 'Уведомления', icon: <IconNotifications size={20} /> },
 ];
 
@@ -27,7 +37,7 @@ export const adminOperationalItems: AdminMenuItem[] = [
   { name: 'units', label: 'Автоматы', icon: <IconUnits size={20} /> },
 ];
 
-/** Справочники, доступные из раздела «Настройки → Справочники». */
+/** Справочники системы (раздел «Справочники», /admin/settings/references). */
 export const adminReferenceItems: AdminMenuItem[] = [
   { name: 'roles', label: 'Роли', icon: <IconRoles size={20} /> },
   { name: 'workshops', label: 'Цеха', icon: <IconWorkshops size={20} /> },

--- a/frontend/src/admin/ui/AdminMobileHeader.tsx
+++ b/frontend/src/admin/ui/AdminMobileHeader.tsx
@@ -1,12 +1,16 @@
 import { useLocation } from 'react-router-dom';
 import { useAdminNav } from './useAdminNav';
-import { IconMenu } from './icons';
+import { IconMenu, IconUserTie } from './icons';
 import { adminMenuItems, adminOperationalItems, adminReferenceItems } from './AdminMenuConfig';
 
+// Более специфичные пути идут раньше: find() возвращает первое совпадение
+// по префиксу, поэтому «settings/references/roles» должен стоять до
+// общего «settings/references».
 const allMenuItems = [
   ...adminOperationalItems,
-  ...adminMenuItems,
   ...adminReferenceItems.map((r) => ({ ...r, name: `settings/references/${r.name}` })),
+  ...adminMenuItems,
+  { name: 'profile', label: 'Профиль', icon: <IconUserTie size={20} /> },
 ];
 
 export function AdminMobileHeader() {

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -91,9 +91,11 @@ export function ProfilePage() {
     source: 'profile',
   });
 
+  // Администратору блок настроек уведомлений не показывается (issue #38),
+  // поэтому и запрос за настройками для него не выполняем.
   const settingsFetch = useAsyncFetch<NotificationSetting[]>(
-    (signal) => fetchNotificationSettings(signal),
-    [],
+    isAdmin ? null : (signal) => fetchNotificationSettings(signal),
+    [isAdmin],
     { source: 'notification-settings' }
   );
 
@@ -248,55 +250,35 @@ export function ProfilePage() {
                 </p>
               </div>
 
-              <div className="rounded-[22px] border border-white/70 bg-white/90 px-4 py-4 shadow-[0_14px_40px_rgba(20,30,50,0.06)]">
-                <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-[#8a8f98]">
-                  {PROFILE_COPY.assignedUnitsLabel}
-                </p>
-                {profileFetch.data?.assignedUnits?.length ? (
-                  <ul className="mt-3 space-y-2 text-sm font-semibold text-[#1A1C1E]">
-                    {profileFetch.data.assignedUnits.map((unit) => (
-                      <li key={unit.unitId} className="flex items-start gap-2">
-                        <span className="text-[#1c6fe8]">•</span>
-                        <span>{unit.unitName}</span>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="mt-3 text-sm font-medium text-[#74777F]">
-                    {PROFILE_COPY.assignedUnitsEmpty}
+              {!isAdmin && (
+                <div className="rounded-[22px] border border-white/70 bg-white/90 px-4 py-4 shadow-[0_14px_40px_rgba(20,30,50,0.06)]">
+                  <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-[#8a8f98]">
+                    {PROFILE_COPY.assignedUnitsLabel}
                   </p>
-                )}
-              </div>
-
-              <div className="mt-2 flex flex-col gap-3">
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={() => setSettingsOpen(true)}
-                    className="flex flex-1 items-center justify-center gap-2 rounded-[18px] bg-[#111827] px-4 py-3 text-sm font-semibold text-white shadow-[0_10px_26px_rgba(15,23,42,0.32)]"
-                  >
-                    <span>{PROFILE_COPY.notificationButton}</span>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleLogoutClick}
-                    aria-label={PROFILE_COPY.logoutButtonAriaLabel}
-                    className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#EA4335] text-white shadow-[0_0_10px_rgba(234,67,53,0.18)] transition-all duration-200 ease-in-out active:scale-[0.98]"
-                  >
-                    <img
-                      src="/assets/logout.svg"
-                      alt=""
-                      aria-hidden="true"
-                      className="h-5 w-5 invert"
-                    />
-                  </button>
+                  {profileFetch.data?.assignedUnits?.length ? (
+                    <ul className="mt-3 space-y-2 text-sm font-semibold text-[#1A1C1E]">
+                      {profileFetch.data.assignedUnits.map((unit) => (
+                        <li key={unit.unitId} className="flex items-start gap-2">
+                          <span className="text-[#1c6fe8]">•</span>
+                          <span>{unit.unitName}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="mt-3 text-sm font-medium text-[#74777F]">
+                      {PROFILE_COPY.assignedUnitsEmpty}
+                    </p>
+                  )}
                 </div>
-                {isAdmin &&
-                  (fromAdmin ? (
+              )}
+
+              <div className="mt-2 flex items-center gap-3">
+                {isAdmin ? (
+                  fromAdmin ? (
                     <button
                       type="button"
                       onClick={() => navigate('/')}
-                      className="flex w-full items-center justify-center gap-2 rounded-[18px] bg-[#0b5da4] px-4 py-3 text-sm font-semibold text-white shadow-[0_10px_26px_rgba(11,93,164,0.32)]"
+                      className="flex flex-1 items-center justify-center gap-2 rounded-[18px] bg-[#0b5da4] px-4 py-3 text-sm font-semibold text-white shadow-[0_10px_26px_rgba(11,93,164,0.32)]"
                     >
                       <span>Мониторинг</span>
                     </button>
@@ -304,11 +286,33 @@ export function ProfilePage() {
                     <button
                       type="button"
                       onClick={() => navigate('/admin')}
-                      className="flex w-full items-center justify-center gap-2 rounded-[18px] bg-[#111827] px-4 py-3 text-sm font-semibold text-white shadow-[0_10px_26px_rgba(15,23,42,0.32)]"
+                      className="flex flex-1 items-center justify-center gap-2 rounded-[18px] bg-[#111827] px-4 py-3 text-sm font-semibold text-white shadow-[0_10px_26px_rgba(15,23,42,0.32)]"
                     >
                       <span>Администрирование</span>
                     </button>
-                  ))}
+                  )
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setSettingsOpen(true)}
+                    className="flex flex-1 items-center justify-center gap-2 rounded-[18px] bg-[#111827] px-4 py-3 text-sm font-semibold text-white shadow-[0_10px_26px_rgba(15,23,42,0.32)]"
+                  >
+                    <span>{PROFILE_COPY.notificationButton}</span>
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={handleLogoutClick}
+                  aria-label={PROFILE_COPY.logoutButtonAriaLabel}
+                  className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#EA4335] text-white shadow-[0_0_10px_rgba(234,67,53,0.18)] transition-all duration-200 ease-in-out active:scale-[0.98]"
+                >
+                  <img
+                    src="/assets/logout.svg"
+                    alt=""
+                    aria-hidden="true"
+                    className="h-5 w-5 invert"
+                  />
+                </button>
               </div>
             </>
           )}


### PR DESCRIPTION
## Что сделано

### Closes #38 — Разделить профиль админа от профиля пользователя мониторинга
- Создана отдельная страница профиля администратора `/admin/profile` (`frontend/src/admin/resources/AdminProfile.tsx`), рендерится внутри `AdminLayout` — шапка администрирования остаётся на месте.
- На странице профиля админа нет блоков «Закрепленное оборудование» и «Настроить уведомления» (они относятся к сотрудникам мониторинга). Структура страницы: заголовок «Профиль», аватар с инициалами, ФИО, чип роли, карточка «Табельный номер», кнопки «Мониторинг» и «Выйти из аккаунта» (с подтверждением).
- Иконка профиля в шапке админки (`AdminHeader`) и пункт «Профиль» в мобильном меню (`AdminBottomSheetMenu`) ведут на `/admin/profile`.
- Профиль мониторинга `/profile` не изменён: из мониторинга админ по-прежнему видит кнопку «Администрирование».

Бэкенд-изменения не потребовались: страница использует существующий `GET /api/v1.0.0/users/me`.

### Closes #49 — Убрать вкладку «Настройки» из шапки админ-панели, заменить на «Справочники»
- Иконка «Настройки» в шапке скрыта через CSS (`hidden`), код кнопки и маршрут `/admin/settings` сохранены на будущее.
- В шапку добавлена иконка «Справочники» (`IconBooks`) → `/admin/settings/references`.
- Хлебные крошки перестроены: цепочка справочников теперь «Справочники → {ресурс} → Создание/Редактирование» без сегмента «Настройки»; хаб справочников — корневой раздел, крошки на нём не показываются.
- Мобильная навигация синхронизирована: в bottom-sheet меню пункт «Настройки» заменён на «Справочники», заголовок мобильной шапки корректно показывает «Справочники»/«Профиль»/конкретный справочник.

## Проверка
- `tsc -b --noEmit` и `eslint --max-warnings 0` — чисто.
- Ручная проверка через Playwright (backend + Vite dev-сервер, вход под админом): шапка без «Настроек», переход по иконке «Справочники», крошки «Справочники → Роли → Редактирование», страница `/admin/profile` с шапкой администрирования и без блоков мониторинга, мобильное меню, прямой доступ к `/admin/settings` сохранён. Ошибок в консоли нет.