### PR TITLE
feat(admin): тесты парсера поисковой строки, кавычки и алиасы полей, фикс зацикливания полосы пилюль

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,8 @@
         "tailwindcss": "^3.4.17",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1823,6 +1824,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.100.10",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.10.tgz",
@@ -1894,6 +1902,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2275,6 +2301,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2395,6 +2534,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/attr-accept": {
       "version": "2.2.5",
@@ -2644,6 +2793,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3056,6 +3215,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3300,6 +3466,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3315,6 +3491,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4103,6 +4289,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4280,6 +4476,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -4410,6 +4620,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5208,6 +5425,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5278,6 +5502,20 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
@@ -5459,6 +5697,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -5516,6 +5761,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -5765,6 +6020,109 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -5788,6 +6146,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "preview": "vite preview",
+    "test": "vitest run",
     "type-check": "tsc -b --noEmit",
     "prepare": "cd .. && husky frontend/.husky"
   },
@@ -50,6 +51,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/admin/filters/TableFilterContext.tsx
+++ b/frontend/src/admin/filters/TableFilterContext.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
 } from 'react';
 import { useListContext } from 'react-admin';
-import { parseSearchQuery, removeFieldToken } from './parser';
+import { parseSearchQuery, formatFieldToken, removeFieldToken } from './parser';
 import type { FieldFilterValue, FilterFieldConfig, TableFilterValues } from './types';
 
 /** Задержка перед отправкой глобального поиска после остановки печати. */
@@ -112,7 +112,7 @@ export function TableFilterProvider({
   const setFieldFilter = useCallback(
     (key: string, value: FieldFilterValue) => {
       // Фильтр из шапки колонки выигрывает у токена в строке поиска
-      setRawSearch((prev) => removeFieldToken(prev, key));
+      setRawSearch((prev) => removeFieldToken(prev, key, fields));
       tokenKeysRef.current = tokenKeysRef.current.filter((k) => k !== key);
       const prev = filterValuesRef.current;
       const next: TableFilterValues = {
@@ -122,12 +122,12 @@ export function TableFilterProvider({
       lastAppliedRef.current = JSON.stringify(next);
       setFilters(next);
     },
-    [setFilters]
+    [fields, setFilters]
   );
 
   const removeFieldFilter = useCallback(
     (key: string) => {
-      setRawSearch((prev) => removeFieldToken(prev, key));
+      setRawSearch((prev) => removeFieldToken(prev, key, fields));
       tokenKeysRef.current = tokenKeysRef.current.filter((k) => k !== key);
       const prev = filterValuesRef.current;
       const nextF = { ...(prev.f ?? {}) };
@@ -139,7 +139,7 @@ export function TableFilterProvider({
       lastAppliedRef.current = JSON.stringify(next);
       setFilters(next);
     },
-    [setFilters]
+    [fields, setFilters]
   );
 
   const clearGlobalSearch = useCallback(() => {
@@ -147,7 +147,7 @@ export function TableFilterProvider({
     setRawSearch((prev) => {
       const parsed = parseSearchQuery(prev, fields);
       const tokens = [
-        ...Object.entries(parsed.structured).map(([k, v]) => `${k}:${v}`),
+        ...Object.entries(parsed.structured).map(([k, v]) => formatFieldToken(k, v)),
         ...parsed.invalidTokens,
       ];
       return tokens.join(' ');

--- a/frontend/src/admin/filters/parser.test.ts
+++ b/frontend/src/admin/filters/parser.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEVICE_CATALOG_FILTER_FIELDS,
+  DEVICE_FILTER_FIELDS,
+  DEVICE_TYPE_FILTER_FIELDS,
+  NOTIFICATION_FILTER_FIELDS,
+  ROLE_FILTER_FIELDS,
+  UNIT_FILTER_FIELDS,
+  USER_FILTER_FIELDS,
+  WORKSHOP_FILTER_FIELDS,
+} from './configs';
+import { formatFieldToken, parseSearchQuery, removeFieldToken, removeRawToken } from './parser';
+import type { FilterFieldConfig } from './types';
+
+/** Все таблицы админ-панели с фильтрацией: [ресурс, конфиг полей]. */
+const ALL_TABLES: Array<[string, FilterFieldConfig[]]> = [
+  ['roles', ROLE_FILTER_FIELDS],
+  ['workshops', WORKSHOP_FILTER_FIELDS],
+  ['device-types', DEVICE_TYPE_FILTER_FIELDS],
+  ['units', UNIT_FILTER_FIELDS],
+  ['device-catalog', DEVICE_CATALOG_FILTER_FIELDS],
+  ['users', USER_FILTER_FIELDS],
+  ['devices', DEVICE_FILTER_FIELDS],
+  ['notifications', NOTIFICATION_FILTER_FIELDS],
+];
+
+describe('parseSearchQuery: все поля всех таблиц', () => {
+  it.each(ALL_TABLES)('%s: каждое поле доступно по ключу', (_resource, fields) => {
+    for (const field of fields) {
+      const parsed = parseSearchQuery(`${field.key}:тест`, fields);
+      expect(parsed.structured, `поле ${field.key}`).toEqual({ [field.key]: 'тест' });
+      expect(parsed.globalSearch).toBe('');
+      expect(parsed.invalidTokens).toEqual([]);
+    }
+  });
+
+  it.each(ALL_TABLES)('%s: каждое поле доступно по однословному label', (_resource, fields) => {
+    for (const field of fields) {
+      if (/\s/.test(field.label)) continue; // многословные label токеном не вводятся
+      const parsed = parseSearchQuery(`${field.label}:тест`, fields);
+      expect(parsed.structured, `label ${field.label}`).toEqual({ [field.key]: 'тест' });
+      expect(parsed.invalidTokens).toEqual([]);
+    }
+  });
+});
+
+describe('parseSearchQuery: глобальный поиск', () => {
+  const fields = USER_FILTER_FIELDS;
+
+  it('пустая строка', () => {
+    expect(parseSearchQuery('', fields)).toEqual({
+      globalSearch: '',
+      structured: {},
+      invalidTokens: [],
+    });
+  });
+
+  it('строка из пробелов', () => {
+    expect(parseSearchQuery('   \t \n ', fields).globalSearch).toBe('');
+  });
+
+  it('свободный текст уходит в q', () => {
+    const parsed = parseSearchQuery('грюнвальд', fields);
+    expect(parsed.globalSearch).toBe('грюнвальд');
+    expect(parsed.structured).toEqual({});
+  });
+
+  it('несколько слов склеиваются пробелом', () => {
+    expect(parseSearchQuery('два слова', fields).globalSearch).toBe('два слова');
+  });
+
+  it('фраза в кавычках остаётся цельной фразой', () => {
+    expect(parseSearchQuery('"два слова" и третье', fields).globalSearch).toBe(
+      'два слова и третье'
+    );
+  });
+
+  it('токен с двоеточием в начале — не фильтр, а текст', () => {
+    expect(parseSearchQuery(':2', fields).globalSearch).toBe(':2');
+  });
+});
+
+describe('parseSearchQuery: структурированные токены', () => {
+  const fields = USER_FILTER_FIELDS;
+
+  it('пример из спецификации: id:2', () => {
+    expect(parseSearchQuery('id:2', fields).structured).toEqual({ id: '2' });
+  });
+
+  it('пример из спецификации: фио:"Логинов Глеб Олегович"', () => {
+    const parsed = parseSearchQuery('фио:"Логинов Глеб Олегович"', fields);
+    expect(parsed.structured).toEqual({ fullName: 'Логинов Глеб Олегович' });
+    expect(parsed.globalSearch).toBe('');
+    expect(parsed.invalidTokens).toEqual([]);
+  });
+
+  it('несколько условий в одной строке (AND)', () => {
+    const parsed = parseSearchQuery('id:2 fullName:иванов активный', fields);
+    expect(parsed.structured).toEqual({ id: '2', fullName: 'иванов' });
+    expect(parsed.globalSearch).toBe('активный');
+  });
+
+  it('регистр ключа не важен: ID:2, Id:2', () => {
+    expect(parseSearchQuery('ID:2', fields).structured).toEqual({ id: '2' });
+    expect(parseSearchQuery('Id:2', fields).structured).toEqual({ id: '2' });
+  });
+
+  it('регистр русского label не важен: ФИО:иванов, Фио:иванов', () => {
+    expect(parseSearchQuery('ФИО:иванов', fields).structured).toEqual({ fullName: 'иванов' });
+    expect(parseSearchQuery('Фио:иванов', fields).structured).toEqual({ fullName: 'иванов' });
+  });
+
+  it('значение передаётся без изменения регистра (бэкенд сам приводит)', () => {
+    expect(parseSearchQuery('fullName:ИвАноВ', fields).structured).toEqual({
+      fullName: 'ИвАноВ',
+    });
+    expect(parseSearchQuery('active:TRUE', fields).structured).toEqual({ active: 'TRUE' });
+  });
+
+  it('повторный ключ: последнее значение выигрывает', () => {
+    expect(parseSearchQuery('id:1 id:2', fields).structured).toEqual({ id: '2' });
+  });
+
+  it('ключ API побеждает при совпадении с чужим label', () => {
+    // В уведомлениях есть и ключ read, и label «Статус» у того же поля;
+    // синтетическая коллизия: ключ совпадает с label другого поля.
+    const collision: FilterFieldConfig[] = [
+      { key: 'type', label: 'Тип', type: 'text' },
+      { key: 'kind', label: 'type', type: 'text' },
+    ];
+    expect(parseSearchQuery('type:x', collision).structured).toEqual({ type: 'x' });
+  });
+});
+
+describe('parseSearchQuery: кавычки', () => {
+  const fields = NOTIFICATION_FILTER_FIELDS;
+
+  it('значение с пробелами в кавычках — один фильтр', () => {
+    const parsed = parseSearchQuery('message:"кончилась плёнка"', fields);
+    expect(parsed.structured).toEqual({ message: 'кончилась плёнка' });
+    expect(parsed.globalSearch).toBe('');
+  });
+
+  it('несколько токенов с кавычками подряд', () => {
+    const parsed = parseSearchQuery('instanceId:"цех 1" deviceCode:"printer 11"', fields);
+    expect(parsed.structured).toEqual({ instanceId: 'цех 1', deviceCode: 'printer 11' });
+  });
+
+  it('незакрытая кавычка — значение до конца строки (ввод на лету)', () => {
+    const parsed = parseSearchQuery('message:"кончилась плён', fields);
+    expect(parsed.structured).toEqual({ message: 'кончилась плён' });
+    expect(parsed.invalidTokens).toEqual([]);
+  });
+
+  it('двоеточие внутри кавычек — часть значения', () => {
+    expect(parseSearchQuery('message:"ошибка: нет связи"', fields).structured).toEqual({
+      message: 'ошибка: нет связи',
+    });
+  });
+
+  it('пустые кавычки — некорректный токен', () => {
+    const parsed = parseSearchQuery('message:""', fields);
+    expect(parsed.structured).toEqual({});
+    expect(parsed.invalidTokens).toEqual(['message:""']);
+  });
+
+  it('текст после закрывающей кавычки склеивается в значение', () => {
+    expect(parseSearchQuery('message:"кончилась" плёнка', fields).structured).toEqual({
+      message: 'кончилась',
+    });
+  });
+});
+
+describe('parseSearchQuery: пробелы и разделители', () => {
+  const fields = ROLE_FILTER_FIELDS;
+
+  it('лишние пробелы между токенами', () => {
+    const parsed = parseSearchQuery('   id:2    name:тест   ', fields);
+    expect(parsed.structured).toEqual({ id: '2', name: 'тест' });
+    expect(parsed.globalSearch).toBe('');
+  });
+
+  it('табуляции и переводы строк разделяют токены', () => {
+    const parsed = parseSearchQuery('id:2\tname:тест\nтекст', fields);
+    expect(parsed.structured).toEqual({ id: '2', name: 'тест' });
+    expect(parsed.globalSearch).toBe('текст');
+  });
+});
+
+describe('parseSearchQuery: некорректные токены', () => {
+  const fields = UNIT_FILTER_FIELDS;
+
+  it('несуществующее поле — в invalidTokens, на бэкенд не уходит', () => {
+    const parsed = parseSearchQuery('foo:bar id:2', fields);
+    expect(parsed.structured).toEqual({ id: '2' });
+    expect(parsed.invalidTokens).toEqual(['foo:bar']);
+    expect(parsed.globalSearch).toBe('');
+  });
+
+  it('несуществующее русское поле', () => {
+    expect(parseSearchQuery('фуу:бар', fields).invalidTokens).toEqual(['фуу:бар']);
+  });
+
+  it('некорректный токен с кавычками хранится как введён', () => {
+    expect(parseSearchQuery('foo:"два слова"', fields).invalidTokens).toEqual(['foo:"два слова"']);
+  });
+
+  it('ключ без значения — некорректный токен', () => {
+    const parsed = parseSearchQuery('name:', fields);
+    expect(parsed.structured).toEqual({});
+    expect(parsed.invalidTokens).toEqual(['name:']);
+    expect(parsed.globalSearch).toBe('');
+  });
+
+  it('дубликаты некорректных токенов схлопываются', () => {
+    expect(parseSearchQuery('foo:1 foo:1', fields).invalidTokens).toEqual(['foo:1']);
+  });
+});
+
+describe('parseSearchQuery: спецсимволы в значениях', () => {
+  const fields = NOTIFICATION_FILTER_FIELDS;
+
+  it('двоеточие в значении без кавычек: сплит по первому', () => {
+    expect(parseSearchQuery('message:код:123', fields).structured).toEqual({
+      message: 'код:123',
+    });
+  });
+
+  it('апостроф не является кавычкой', () => {
+    expect(parseSearchQuery("message:O'Brien", fields).structured).toEqual({
+      message: "O'Brien",
+    });
+  });
+
+  it('запятая передаётся как есть (бэкенд трактует как OR)', () => {
+    expect(parseSearchQuery('type:INFO,WARNING', fields).structured).toEqual({
+      type: 'INFO,WARNING',
+    });
+  });
+
+  it('ё и unicode в значениях', () => {
+    expect(parseSearchQuery('message:плёнка-«стоп»', fields).structured).toEqual({
+      message: 'плёнка-«стоп»',
+    });
+  });
+
+  it('дата как значение', () => {
+    expect(parseSearchQuery('createdAt:2026-08-04', fields).structured).toEqual({
+      createdAt: '2026-08-04',
+    });
+  });
+});
+
+describe('removeFieldToken', () => {
+  const fields = USER_FILTER_FIELDS;
+
+  it('удаляет токен по ключу', () => {
+    expect(removeFieldToken('id:2 fullName:иван', 'id', fields)).toBe('fullName:иван');
+  });
+
+  it('удаляет токен независимо от регистра ключа', () => {
+    expect(removeFieldToken('ID:2 name:x', 'id', fields)).toBe('name:x');
+  });
+
+  it('удаляет токен, введённый через label-алиас', () => {
+    expect(removeFieldToken('фио:иван id:2', 'fullName', fields)).toBe('id:2');
+  });
+
+  it('удаляет токен со значением в кавычках целиком', () => {
+    expect(removeFieldToken('фио:"Логинов Глеб Олегович" id:2', 'fullName', fields)).toBe('id:2');
+  });
+
+  it('удаляет токен неизвестного поля по сырому ключу (пилюля ошибки)', () => {
+    expect(removeFieldToken('foo:bar id:2', 'foo', fields)).toBe('id:2');
+  });
+
+  it('не трогает токены других полей и свободный текст', () => {
+    expect(removeFieldToken('id:2 текст name:x', 'fullName', fields)).toBe('id:2 текст name:x');
+  });
+
+  it('отсутствующий токен — строка без изменений', () => {
+    expect(removeFieldToken('id:2', 'code', fields)).toBe('id:2');
+  });
+});
+
+describe('removeRawToken', () => {
+  it('удаляет точное совпадение токена', () => {
+    expect(removeRawToken('foo:bar id:2', 'foo:bar')).toBe('id:2');
+  });
+
+  it('удаляет токен с кавычками', () => {
+    expect(removeRawToken('foo:"два слова" id:2', 'foo:"два слова"')).toBe('id:2');
+  });
+
+  it('удаляет все дубликаты токена', () => {
+    expect(removeRawToken('foo:1 foo:1 id:2', 'foo:1')).toBe('id:2');
+  });
+
+  it('не совпавшийся токен — строка без изменений', () => {
+    expect(removeRawToken('foo:1', 'bar:2')).toBe('foo:1');
+  });
+});
+
+describe('formatFieldToken', () => {
+  it('значение без пробелов — как есть', () => {
+    expect(formatFieldToken('id', '2')).toBe('id:2');
+  });
+
+  it('значение с пробелами оборачивается в кавычки', () => {
+    expect(formatFieldToken('fullName', 'Логинов Глеб')).toBe('fullName:"Логинов Глеб"');
+  });
+
+  it('round-trip: токен переживает повторный парсинг', () => {
+    const fields = USER_FILTER_FIELDS;
+    const token = formatFieldToken('fullName', 'Логинов Глеб Олегович');
+    expect(parseSearchQuery(token, fields).structured).toEqual({
+      fullName: 'Логинов Глеб Олегович',
+    });
+  });
+});

--- a/frontend/src/admin/filters/parser.ts
+++ b/frontend/src/admin/filters/parser.ts
@@ -8,8 +8,81 @@ export interface ParsedSearchQuery {
   globalSearch: string;
   /** Распарсенные структурированные фильтры `ключ:значение`. */
   structured: Record<string, string>;
-  /** Токены вида `ключ:значение` с неизвестным ключом — не отправляются на бэкенд. */
+  /** Токены вида `ключ:значение` с неизвестным ключом или пустым значением — не отправляются на бэкенд. */
   invalidTokens: string[];
+}
+
+/**
+ * Токен поисковой строки: последовательность сегментов без пробелов между ними.
+ * Сегмент — либо текст в двойных кавычках (сохраняет пробелы внутри),
+ * либо обычный текст до ближайшего пробела или кавычки.
+ */
+interface SearchToken {
+  /** Исходный текст токена как введён (для отображения и удаления). */
+  raw: string;
+  /** Раскодированный текст: кавычки сняты, содержимое сегментов склеено. */
+  text: string;
+}
+
+/**
+ * Разбивает строку на токены. Правила:
+ *  - токены разделяются пробельными символами;
+ *  - `"..."` — один сегмент, пробелы внутри сохраняются;
+ *  - незакрытая кавычка поглощает строку до конца (строка парсится
+ *    на каждом keystroke, поэтому неполный ввод — штатная ситуация);
+ *  - сегменты без пробела между ними склеиваются в один токен
+ *    (`ключ:"два слова"` — один токен).
+ */
+function tokenize(input: string): SearchToken[] {
+  const tokens: SearchToken[] = [];
+  const length = input.length;
+  let i = 0;
+
+  while (i < length) {
+    if (/\s/.test(input[i])) {
+      i++;
+      continue;
+    }
+    const start = i;
+    let text = '';
+    while (i < length && !/\s/.test(input[i])) {
+      if (input[i] === '"') {
+        const close = input.indexOf('"', i + 1);
+        if (close === -1) {
+          text += input.slice(i + 1);
+          i = length;
+        } else {
+          text += input.slice(i + 1, close);
+          i = close + 1;
+        }
+      } else {
+        const start2 = i;
+        while (i < length && !/\s/.test(input[i]) && input[i] !== '"') i++;
+        text += input.slice(start2, i);
+      }
+    }
+    tokens.push({ raw: input.slice(start, i), text });
+  }
+  return tokens;
+}
+
+/**
+ * Строит карту «введённое имя поля (в нижнем регистре) → ключ поля».
+ * Поле можно указать ключом API (`fullName`) или, для однословных
+ * label, названием колонки (`фио`). При совпадении приоритет у ключа.
+ */
+function buildFieldLookup(fields: FilterFieldConfig[]): Map<string, string> {
+  const lookup = new Map<string, string>();
+  for (const field of fields) {
+    const labelKey = field.label.toLowerCase();
+    if (!lookup.has(labelKey)) {
+      lookup.set(labelKey, field.key);
+    }
+  }
+  for (const field of fields) {
+    lookup.set(field.key.toLowerCase(), field.key);
+  }
+  return lookup;
 }
 
 /**
@@ -18,9 +91,14 @@ export interface ParsedSearchQuery {
  * Правила:
  *  - условия разделяются пробелами (логика AND);
  *  - токен с первым двоеточием — `ключ:значение` (структурированный фильтр);
- *  - ключ должен совпадать с одним из описанных полей (регистронезависимо);
- *  - токен с неизвестным ключом попадает в invalidTokens и не отправляется;
- *  - остальной текст — глобальный поиск.
+ *  - ключ совпадает с ключом поля или его однословным label (регистронезависимо);
+ *  - значение с пробелами берётся в двойные кавычки: `фио:"Иванов Иван"`;
+ *  - токен с неизвестным ключом или пустым значением попадает в invalidTokens
+ *    и не отправляется;
+ *  - остальной текст — глобальный поиск (кавычки снимаются, фраза в кавычках
+ *    остаётся цельной);
+ *  - значения передаются бэкенду как введены: текст ищется регистронезависимо,
+ *    булевы и enum-значения бэкенд приводит к каноническому виду сам.
  *
  * Без скобок, OR и операторов сравнения внутри строки (Фаза 1).
  */
@@ -29,37 +107,72 @@ export function parseSearchQuery(input: string, fields: FilterFieldConfig[]): Pa
   const invalidTokens: string[] = [];
   const globalParts: string[] = [];
 
-  const byKey = new Map(fields.map((f) => [f.key.toLowerCase(), f.key]));
+  const lookup = buildFieldLookup(fields);
 
-  for (const token of input.split(/\s+/).filter(Boolean)) {
-    const colon = token.indexOf(':');
-    if (colon > 0 && colon < token.length - 1) {
-      const rawKey = token.slice(0, colon);
-      const value = token.slice(colon + 1);
-      const key = byKey.get(rawKey.toLowerCase());
-      if (key) {
+  for (const token of tokenize(input)) {
+    const colon = token.text.indexOf(':');
+    if (colon > 0) {
+      const key = lookup.get(token.text.slice(0, colon).toLowerCase());
+      const value = token.text.slice(colon + 1);
+      if (key && value) {
         structured[key] = value;
       } else {
-        invalidTokens.push(token);
+        invalidTokens.push(token.raw);
       }
-    } else {
-      globalParts.push(token);
+    } else if (token.text) {
+      globalParts.push(token.text);
     }
   }
 
   return {
     globalSearch: globalParts.join(' '),
     structured,
-    invalidTokens,
+    // Дубликаты некорректных токенов схлопываем: пилюля ошибки одна,
+    // иначе React получает повторяющиеся key.
+    invalidTokens: [...new Set(invalidTokens)],
   };
 }
 
-/** Удаляет токен `ключ:значение` для указанного поля из сырой строки поиска. */
-export function removeFieldToken(input: string, fieldKey: string): string {
-  const prefix = `${fieldKey.toLowerCase()}:`;
-  return input
-    .split(/\s+/)
-    .filter((token) => !token.toLowerCase().startsWith(prefix))
+/** Удаляет из строки токен, в точности совпадающий с переданным (например, некорректный). */
+export function removeRawToken(input: string, rawToken: string): string {
+  return tokenize(input)
+    .filter((token) => token.raw !== rawToken)
+    .map((token) => token.raw)
+    .join(' ')
+    .trim();
+}
+
+/**
+ * Собирает токен `ключ:значение` обратно в строку. Значение с пробельными
+ * символами оборачивается в кавычки, чтобы токен пережил повторный парсинг.
+ */
+export function formatFieldToken(fieldKey: string, value: string): string {
+  return /\s/.test(value) ? `${fieldKey}:"${value}"` : `${fieldKey}:${value}`;
+}
+
+/**
+ * Удаляет токен `ключ:значение` для указанного поля из сырой строки поиска.
+ * Поле распознаётся по ключу и однословному label (как при парсинге);
+ * для неизвестных полей — точное совпадение ключа токена (удаление
+ * некорректных токенов из пилюли ошибки).
+ */
+export function removeFieldToken(
+  input: string,
+  fieldKey: string,
+  fields: FilterFieldConfig[]
+): string {
+  const lookup = buildFieldLookup(fields);
+  const target = fieldKey.toLowerCase();
+  return tokenize(input)
+    .filter((token) => {
+      const colon = token.text.indexOf(':');
+      if (colon <= 0) return true;
+      const rawKey = token.text.slice(0, colon).toLowerCase();
+      const resolved = lookup.get(rawKey);
+      const matches = resolved ? resolved === fieldKey : rawKey === target;
+      return !matches;
+    })
+    .map((token) => token.raw)
     .join(' ')
     .trim();
 }

--- a/frontend/src/admin/ui/FilterToolbar.tsx
+++ b/frontend/src/admin/ui/FilterToolbar.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useRef, useState, type ReactNode } from 'react';
 import { useTableFilters } from '../filters/TableFilterContext';
-import { removeFieldToken } from '../filters/parser';
+import { removeRawToken } from '../filters/parser';
 import type { ComparisonFilterValue, FieldFilterValue, FilterFieldConfig } from '../filters/types';
 import { useNameMap } from './useNameMap';
 import { IconSearch, IconX } from './icons';
@@ -68,9 +68,7 @@ export function FilterToolbar({ actions }: { actions?: ReactNode }) {
                   key={token}
                   tone="error"
                   label={`Некорректный фильтр: ${token}`}
-                  onRemove={() =>
-                    ctx.setRawSearch(removeFieldToken(rawSearch, token.split(':')[0]))
-                  }
+                  onRemove={() => ctx.setRawSearch(removeRawToken(rawSearch, token))}
                 />
               ))}
             </ChipStripScroller>
@@ -96,7 +94,8 @@ export function FilterToolbar({ actions }: { actions?: ReactNode }) {
               {ex}
             </code>
           ))}
-          . Несколько условий — через пробел.
+          . Несколько условий — через пробел, значение с пробелами — в двойных кавычках. Поле можно
+          указать ключом или названием колонки.
         </p>
       )}
     </div>
@@ -124,17 +123,24 @@ function ChipStripScroller({ children }: { children: ReactNode }) {
     const el = scrollRef.current;
     if (!el) return;
 
+    // Замер откладываем в rAF: setState синхронно в layout-эффекте
+    // при каскаде рендеров (применение фильтров из строки поиска)
+    // превращался в Maximum update depth exceeded и ронял страницу.
+    let raf = 0;
     const update = () => {
-      const { scrollWidth, clientWidth, scrollLeft } = el;
-      setThumb((prev) => {
-        if (scrollWidth <= clientWidth + 1) return prev === null ? prev : null;
-        const width = Math.max(24, (clientWidth / scrollWidth) * clientWidth);
-        const left = (scrollLeft / (scrollWidth - clientWidth)) * (clientWidth - width);
-        // Без этого сравнения каждый рендер кладёт в стейт новый объект
-        // и зацикливает эффект (Maximum update depth exceeded).
-        return prev && Math.abs(prev.left - left) < 0.5 && Math.abs(prev.width - width) < 0.5
-          ? prev
-          : { left, width };
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        const { scrollWidth, clientWidth, scrollLeft } = el;
+        setThumb((prev) => {
+          if (scrollWidth <= clientWidth + 1) return prev === null ? prev : null;
+          const width = Math.max(24, (clientWidth / scrollWidth) * clientWidth);
+          const left = (scrollLeft / (scrollWidth - clientWidth)) * (clientWidth - width);
+          // Без этого сравнения каждый кадр клал бы в стейт новый объект
+          // и зацикливал перерисовку.
+          return prev && Math.abs(prev.left - left) < 0.5 && Math.abs(prev.width - width) < 0.5
+            ? prev
+            : { left, width };
+        });
       });
     };
 
@@ -142,6 +148,7 @@ function ChipStripScroller({ children }: { children: ReactNode }) {
     el.addEventListener('scroll', update, { passive: true });
     window.addEventListener('resize', update);
     return () => {
+      cancelAnimationFrame(raf);
       el.removeEventListener('scroll', update);
       window.removeEventListener('resize', update);
     };
@@ -246,7 +253,11 @@ function FilterValueLabel({ field, value }: { field: FilterFieldConfig; value: F
   if (field.reference) {
     return <ReferenceValuesLabel field={field} values={values} />;
   }
-  const mapped = values.map((v) => field.options?.find((o) => o.value === v)?.label ?? v);
+  // Бэкенд приводит enum/bool-значения к каноническому виду сам, поэтому опции
+  // сопоставляем без учёта регистра — иначе пилюля показывала бы сырое значение.
+  const mapped = values.map(
+    (v) => field.options?.find((o) => o.value.toLowerCase() === v.toLowerCase())?.label ?? v
+  );
   return <>{mapped.join(', ')}</>;
 }
 


### PR DESCRIPTION
### Closes #50

## Что сделано

### Тесты парсера (основа задачи)
- Подключён **vitest** (devDependency, скрипт `npm test` в `frontend/package.json`).
- `frontend/src/admin/filters/parser.test.ts` — **62 теста**, все зелёные:
  - параметризованный прогон **всех полей всех 8 таблиц** из `configs.ts` (сотрудники, автоматы, цеха, устройства, уведомления, справочники и т.д.);
  - краевые случаи из issue: приведение к нижнему регистру (и ключей, и значений), лишние пробелы, значения с пробелами в двойных кавычках (`фио:"Логинов Глеб Олегович"`), несколько условий в одной строке, несуществующие поля, спецсимволы, пустые значения;
  - round-trip `formatFieldToken` → `parseSearchInput` → `removeFieldToken` / `removeRawToken`.

### Исправления парсера (`parser.ts`), найденные тестами
- **Токенизатор с кавычками**: `ключ:"значение с пробелами"` теперь разбирается корректно (раньше значение обрезалось по первому пробелу). Незакрытая кавычка = значение до конца строки; сегменты вне/внутри кавычек склеиваются.
- **Алиасы label → key**: однословные русские названия колонок (`фио:`, `тип:` и т.п., регистронезависимо) резолвятся в ключ API; ключ API приоритетнее label — по спеке #37. Пример из issue `фио:"..."` работает.
- **Пустое значение** (`name:`, `name:""`) уходит в `invalidTokens`, а не применяется как пустой фильтр.
- Дедуп `invalidTokens`; экспортированы `formatFieldToken` (реквотинг значений с пробелами) и `removeRawToken` (для пилюли ошибки).
- `removeFieldToken(input, fieldKey, fields)` — новая сигнатура с `fields`, чтобы токен удалялся и по алиасу; вызовы обновлены в `TableFilterContext.tsx` (+ `clearGlobalSearch` через `formatFieldToken`), хинт в `FilterToolbar.tsx` дополнен про кавычки и названия колонок.

### Найденный в процессе баг (воспроизведён на чистом `main`)
- `ChipStripScroller` в `FilterToolbar.tsx` ронял страницу с **Maximum update depth exceeded** (react-admin error fallback) при каскаде рендеров после применения фильтров — setState синхронно в layout-эффекте без deps. Подтверждено на `main` через `git stash`. Фикс: замер обёрнут в `requestAnimationFrame` с `cancelAnimationFrame`, толеранс-гард 0.5px сохранён.

### Косметика пилюли
- `FilterValueLabel`: опции сопоставляются без учёта регистра — бэкенд сам приводит enum/bool к каноническому виду, поэтому `тип:device_disconnected` теперь показывает «Тип: Устройство отключено» вместо сырого значения.

## Проверка
- `npx vitest run` — 62/62 зелёные; `tsc -b --noEmit` и `eslint --max-warnings 0` чисто (husky pre-commit тоже прошёл).
- Бэкенд запущен локально, E2E через Playwright (мобильный вьюпорт 390×844):
  - `id:1` → `f.id=1`, строка найдена;
  - `фио:"Second User"` → `f.fullName` (алиас + кавычки);
  - `foo:bar` → красная пилюля «Некорректный фильтр», на бэкенд не уходит, удаление пилюли чистое;
  - 5 условий в одной строке → все в URL;
  - `тип:device_disconnected` на уведомлениях → `f.type`, бэкенд съел lowercase-enum, 21 строка «Устройство отключено»;
  - ранее падавший сценарий `fullName:"Second User" id:1 foo:bar` — 0 ошибок консоли, ползунок полосы пилюль работает.