### PR TITLE
feat(admin): запрет самодеактивации и самоудаления администратора (#60)

### DIFF
--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUserController.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/api/controller/admin/AdminUserController.java
@@ -104,11 +104,16 @@ public class AdminUserController {
         RoleEntity role = roleRepository.findById(request.roleId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Роль не найдена"));
 
-        // Роль самого себя менять нельзя никогда — иначе админ может
-        // понизить сам себя и потерять/получить доступ в середине сессии.
+        // Над собственной учёткой запрещены: смена роли и деактивация —
+        // иначе админ может потерять доступ в середине сессии.
         Long currentUserId = JwtPrincipalUtil.getCurrentUserId();
-        if (id.equals(currentUserId) && !request.roleId().equals(user.getRoleId())) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "Нельзя изменить роль самому себе");
+        if (id.equals(currentUserId)) {
+            if (!request.roleId().equals(user.getRoleId())) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "Нельзя изменить роль самому себе");
+            }
+            if (user.isActive() && !request.active()) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "Нельзя деактивировать самого себя");
+            }
         }
 
         if (request.code() != null && !request.code().isBlank() && !request.code().equals(user.getCode())) {
@@ -140,6 +145,11 @@ public class AdminUserController {
     public ResponseEntity<Void> delete(@PathVariable @NonNull Long id) {
         if (!userRepository.existsById(id)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Пользователь не найден");
+        }
+        // Админ не может удалить собственную учётку — иначе потеряет доступ
+        // в середине сессии, а система может остаться без администратора.
+        if (id.equals(JwtPrincipalUtil.getCurrentUserId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Нельзя удалить самого себя");
         }
         // Составная сущность «Сотрудник»: удаляем все оперативные записи,
         // ссылающиеся на пользователя, до удаления самой записи в users.


### PR DESCRIPTION
Follow-up к #61 (issue #60).

Защита собственной учётки администратора в `AdminUserController`:

- `PUT /admin/users/{id}` — 409 «Нельзя деактивировать самого себя» при `active=false` на собственной записи (дополняет запрет смены собственной роли из #61);
- `DELETE /admin/users/{id}` — 409 «Нельзя удалить самого себя» (ранее самоудаление было возможно).

Мотивация: админ не должен иметь возможности заблокировать сам себя в середине сессии / оставить систему без администратора.

Проверено REST-прогоном от имени админа: self-deactivate → 409, self-delete → 409, обычное редактирование себя → 200, деактивация/реактивация другого пользователя → 200.

Relates to #60