### PR TITLE
fix(admin): копирование учётных данных в незащищённом контексте (#78)

### DIFF
--- a/frontend/src/admin/ui/GeneratedCredentialsDialog.tsx
+++ b/frontend/src/admin/ui/GeneratedCredentialsDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { PillButton } from './PillButton';
 import { IconCopy, IconCheck } from './icons';
+import { copyToClipboard } from '../../utils/clipboard';
 
 interface GeneratedCredentialsDialogProps {
   isOpen: boolean;
@@ -40,17 +41,14 @@ export function GeneratedCredentialsDialog({
   if (!isOpen) return null;
 
   const handleCopy = async (text: string, type: 'code' | 'password') => {
-    try {
-      await navigator.clipboard.writeText(text);
-      if (type === 'code') {
-        setCopiedCode(true);
-        setTimeout(() => setCopiedCode(false), 1500);
-      } else {
-        setCopiedPassword(true);
-        setTimeout(() => setCopiedPassword(false), 1500);
-      }
-    } catch {
-      // игнорируем ошибки копирования
+    const ok = await copyToClipboard(text);
+    if (!ok) return;
+    if (type === 'code') {
+      setCopiedCode(true);
+      setTimeout(() => setCopiedCode(false), 1500);
+    } else {
+      setCopiedPassword(true);
+      setTimeout(() => setCopiedPassword(false), 1500);
     }
   };
 

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,0 +1,36 @@
+// Копирование текста в буфер обмена.
+// navigator.clipboard доступен только в Secure Context (https/localhost),
+// поэтому при работе по http:// (внутренняя сеть) используем fallback
+// через временный textarea + document.execCommand('copy').
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (window.isSecureContext && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Падение возможно при потере фокуса документа — пробуем fallback
+    }
+  }
+  return copyViaExecCommand(text);
+}
+
+function copyViaExecCommand(text: string): boolean {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  // Прячем за пределами viewport, чтобы не было скачка скролла
+  textarea.style.position = 'fixed';
+  textarea.style.top = '0';
+  textarea.style.left = '-9999px';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, text.length); // для iOS
+  try {
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}


### PR DESCRIPTION
## Что сделано

Closes #78

**Проблема:** в админ-панели при сбросе пароля сотрудника кнопки «Копировать» (табельный номер, пароль) в overlay с временным паролем не копировали значения в буфер обмена. Причина — `navigator.clipboard` доступен только в Secure Context (https/localhost), а во внутренней сети фронтенд открывается по `http://` (например, `http://10.30.0.5:5500`).

**Решение:**
- Новый хелпер `frontend/src/utils/clipboard.ts` → `copyToClipboard(text)`:
  - в Secure Context использует `navigator.clipboard.writeText` (с fallback при ошибке, например потере фокуса документа);
  - в незащищённом контексте — fallback через временный `textarea` + `document.execCommand('copy')`.
- `GeneratedCredentialsDialog` использует хелпер; индикатор «Скопировано» показывается только при реально успешном копировании (раньше ошибка молча проглатывалась).

## Проверка

- `tsc -b --noEmit` и `eslint` — чисто; pre-commit хуки (prettier/eslint/type-check) прошли.
- E2E через Playwright в условиях, воспроизводящих баг (`http://<LAN-IP>:5500`, `isSecureContext === false`, `navigator.clipboard` недоступен):
  - вход админом → Сотрудники → редактирование → «Сбросить пароль» → overlay с учётными данными;
  - обе кнопки «Копировать» копируют корректные значения (проверено перехватом `execCommand`: `10010` и сгенерированный пароль), `execCommand('copy')` возвращает `true`;
  - на обеих кнопках появляется состояние «Скопировано».