### PR TITLE
fix: состояние уведомления у создателя, статус устройств и иконка бейджа

### DIFF
--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/ws/LiveWsHandler.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/infrastructure/ws/LiveWsHandler.java
@@ -206,10 +206,14 @@ public class LiveWsHandler extends TextWebSocketHandler {
     }
 
     /**
-     * Рассылает {@code NOTIFICATION} всем подключённым клиентам.
+     * Рассылает {@code NOTIFICATION} клиентам, которым разрешено видеть уведомление:
+     * подписчикам аппарата (настройки Android-звонка) и создателю уведомления.
      * <p>
-     * Аналог {@link #broadcastAlert(String)} — используется {@code StatusBroadcaster}
-     * для немедленной рассылки при toggle-событии.
+     * Создатель получает дельту всегда, независимо от своих настроек оповещений:
+     * иначе его собственная сессия не узнает о смене состояния и не обновит
+     * кнопку, список уведомлений и иконку.
+     * <p>
+     * Используется {@code StatusBroadcaster} для немедленной рассылки при toggle-событии.
      *
      * @param notification сериализованный {@link dev.savushkin.scada.mobile.backend.api.dto.NotificationMessageDTO}
      */
@@ -222,7 +226,7 @@ public class LiveWsHandler extends TextWebSocketHandler {
                 allSessions.remove(session);
                 continue;
             }
-            if (!isNotificationAllowed(session, notification.unitId())) {
+            if (!isCreator(session, notification) && !isNotificationAllowed(session, notification.unitId())) {
                 continue;
             }
             try {
@@ -357,18 +361,16 @@ public class LiveWsHandler extends TextWebSocketHandler {
     }
 
     /**
-     * Отправляет снимок всех активных производственных уведомлений новому клиенту.
+     * Отправляет снимок активных производственных уведомлений, видимых новому клиенту:
+     * по подпискам аппаратов (настройки Android-звонка) плюс созданные им самим.
      * Вызывается сразу после {@code ALERT_SNAPSHOT} при установке соединения.
      */
     private void sendNotificationSnapshot(WebSocketSession session) {
         try {
             Set<String> allowedUnitIds = resolveAllowedNotificationUnits(session);
-            List<NotificationMessageDTO> allNotifications = notificationStore.getAll();
-            List<NotificationMessageDTO> filtered = allowedUnitIds.isEmpty()
-                    ? List.of()
-                    : allNotifications.stream()
-                        .filter(n -> allowedUnitIds.contains(n.unitId()))
-                        .toList();
+            List<NotificationMessageDTO> filtered = notificationStore.getAll().stream()
+                    .filter(n -> allowedUnitIds.contains(n.unitId()) || isCreator(session, n))
+                    .toList();
             var snapshotMsg = NotificationSnapshotMessageDTO.of(filtered);
             sendMessageSafely(session, objectMapper.writeValueAsString(snapshotMsg));
             log.debug("WS /live: sent NOTIFICATION_SNAPSHOT, notifications={}, id={}",
@@ -398,6 +400,20 @@ public class LiveWsHandler extends TextWebSocketHandler {
     private boolean isNotificationAllowed(WebSocketSession session, String unitId) {
         Set<String> allowed = resolveAllowedNotificationUnits(session);
         return !allowed.isEmpty() && allowed.contains(unitId);
+    }
+
+    /**
+     * Проверяет, является ли пользователь сессии создателем уведомления.
+     * Создатель всегда видит собственное уведомление, даже если не включал
+     * оповещения для этого аппарата.
+     */
+    private boolean isCreator(WebSocketSession session, NotificationMessageDTO notification) {
+        String creatorId = notification.creatorId();
+        if (creatorId == null || creatorId.isBlank()) {
+            return false;
+        }
+        OptionalLong userId = resolveUserId(session);
+        return userId.isPresent() && creatorId.equals(Long.toString(userId.getAsLong()));
     }
 
     private OptionalLong resolveUserId(WebSocketSession session) {

--- a/backend/src/main/java/dev/savushkin/scada/mobile/backend/services/UnitDetailService.java
+++ b/backend/src/main/java/dev/savushkin/scada/mobile/backend/services/UnitDetailService.java
@@ -108,7 +108,8 @@ public class UnitDetailService {
 
     /**
      * Строит статус камеры, используя как device-поля, так и scada-ключ.
-     * Поле {@code st} берётся из поля {@code ST} снапшота устройства (0 — нет ошибки, 1 — ошибка).
+     * Поле {@code st} берётся из поля {@code ST} снапшота устройства
+     * (0 — остановлено, 1 — работает); флаг ошибки — отдельное поле {@code Error}.
      */
     private static DevicesStatusMessageDTO.CameraStatus buildSingleCamStatus(
             String camName,

--- a/frontend/src/components/UnitCard.tsx
+++ b/frontend/src/components/UnitCard.tsx
@@ -207,7 +207,7 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
                   title="Активное уведомление"
                 >
                   <img
-                    src={isActiveByMe ? '/assets/bell.svg' : '/assets/bell-off.svg'}
+                    src="/assets/bell.svg"
                     alt=""
                     aria-hidden="true"
                     className="h-5 w-5"

--- a/frontend/src/constants/statusUtils.test.ts
+++ b/frontend/src/constants/statusUtils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { getDeviceStatusLevel } from './statusUtils';
+import type { DevicesStatusPayload } from '../types';
+
+describe('getDeviceStatusLevel', () => {
+  it('pending — WS-данные ещё не пришли', () => {
+    expect(getDeviceStatusLevel(null, 'Printer11')).toBe('pending');
+  });
+
+  it('pending — устройства нет в payload', () => {
+    expect(getDeviceStatusLevel({}, 'Printer11')).toBe('pending');
+  });
+
+  it('disconnected — устройство отключено (даже при Error=1)', () => {
+    const wsData: DevicesStatusPayload = {
+      Printer11: { st: 0, error: 1, disconnected: true },
+    };
+    expect(getDeviceStatusLevel(wsData, 'Printer11')).toBe('disconnected');
+  });
+
+  it('error — реальная ошибка устройства (Error=1)', () => {
+    const wsData: DevicesStatusPayload = {
+      Printer11: { st: 1, error: 1, disconnected: false },
+    };
+    expect(getDeviceStatusLevel(wsData, 'Printer11')).toBe('error');
+  });
+
+  // Регрессия issue #79: работающее устройство (ST=1, Error=0) — зелёное, не красное.
+  it('ok — устройство работает (ST=1) без ошибки (Error=0)', () => {
+    const wsData: DevicesStatusPayload = {
+      Printer11: { st: 1, error: 0, disconnected: false },
+    };
+    expect(getDeviceStatusLevel(wsData, 'Printer11')).toBe('ok');
+  });
+
+  it('ok — устройство остановлено (ST=0) без ошибки', () => {
+    const wsData: DevicesStatusPayload = {
+      Printer11: { st: 0, error: 0, disconnected: false },
+    };
+    expect(getDeviceStatusLevel(wsData, 'Printer11')).toBe('ok');
+  });
+});

--- a/frontend/src/constants/statusUtils.ts
+++ b/frontend/src/constants/statusUtils.ts
@@ -89,18 +89,21 @@ export const WORKSHOP_STATUS_CLASS: Record<WorkshopStatusLevel, string> = {
  * Уровни статуса карточки устройства.
  *
  * - `'pending'` — WS-данные ещё не пришли; статус неизвестен. Карточка серая.
- * - `'error'`   — устройство сообщило об ошибке (st === 1). Карточка красная.
- * - `'ok'`      — ошибок нет (st === 0). Карточка зелёная.
+ * - `'error'`   — устройство сообщило об ошибке (error === 1). Карточка красная.
+ * - `'ok'`      — ошибок нет (error !== 1). Карточка зелёная.
  */
 export type DeviceStatusLevel = 'pending' | 'error' | 'ok' | 'disconnected';
 
 /**
  * Определяет уровень статуса устройства по имени и текущим WS-данным.
  *
+ * Поле `st` (ST в PrintSrv) — признак «устройство работает» (0 — остановлено,
+ * 1 — работает), а не ошибка; реальный флаг ошибки — поле `error`.
+ *
  * Приоритет:
  * 1. `wsData === null` — WS ещё не прислал ни одного `DEVICES_STATUS` → `pending`.
  * 2. `info.disconnected === true` → `disconnected` (серый, бейдж "Отключено").
- * 3. `info.st === 1` → `error` (красная).
+ * 3. `info.error === 1` → `error` (красная).
  * 4. Иначе → `ok` (зелёная).
  */
 export function getDeviceStatusLevel(
@@ -111,7 +114,7 @@ export function getDeviceStatusLevel(
   const info = wsData[name];
   if (!info) return 'pending';
   if (info.disconnected) return 'disconnected';
-  if (info.st === DOMAIN_FLAGS.active) return 'error';
+  if (info.error === DOMAIN_FLAGS.active) return 'error';
   return 'ok';
 }
 


### PR DESCRIPTION
## Сводка

Исправлены три связанных бага отображения состояния уведомлений и устройств.

### #72 — уведомление «последняя партия» не обновляло состояние у установившего пользователя

**Корневая причина (бэкенд):** `LiveWsHandler.broadcastNotification` и `sendNotificationSnapshot` фильтровали доставку по настройкам Android-звонка (`getAndroidCallEnabledPrintSrvUnitIds`). Если создатель уведомления не включал оповещения для этого аппарата, его собственная сессия никогда не получала WS-дельту — фронтенд применяет NOTIFICATION без фильтров, ему просто нечего было применять. Отсюда все симптомы: пустой список уведомлений, кнопка без смены состояния, иконка свайпа, а также текст установки («Отправить последнюю партию?») в overlay при снятии — из-за протухшего состояния `isActiveByMe` оставался `false` (тексты overlay для установки/снятия в коде уже разделены).

**Исправление:** дельта и снапшот доставляются также создателю уведомления (сравнение `creatorId` с userId сессии), независимо от его настроек оповещений. Правило видимости для остальных пользователей не изменилось.

### #79 — красные карточки устройств при корректных данных

**Корневая причина (фронтенд):** `getDeviceStatusLevel` считал `st === 1` ошибкой. По домену PrintSrv `ST` — признак «устройство работает» (0 — остановлено, 1 — работает), а реальный флаг ошибки — отдельное поле `Error` (нормализовалось, но не проверялось). Все работающие устройства отображались красным.

**Исправление:** критерий красного состояния — `error === 1`; заодно исправлен противоречащий javadoc `UnitDetailService` (там `ST` был описан как флаг ошибки). Добавлен регрессионный тест `statusUtils.test.ts`.

### #77 — перечёркнутый колокольчик при активном уведомлении

**Корневая причина (фронтенд):** бейдж в списке автоматов выбирал `bell-off.svg` для активного уведомления, созданного другим пользователем.

**Исправление:** бейдж «Активное уведомление» всегда использует `bell.svg` (перечёркнутый вариант остаётся только для действий «снять» — FAB и свайп, где семантика иконки — действие, а не состояние).

## Проверка

- `tsc --noEmit`, `eslint`, `vitest` (68 тестов) — зелёные; `./gradlew compileJava` — зелёная.
- Ручная проверка через Playwright (dev-профиль, админ 10002): установка уведомления → FAB переходит в «Снять уведомление», запись появляется в списке уведомлений (счётчик в шапке), иконка свайпа — «снять»; состояние переживает перезагрузку страницы (снапшот); overlay снятия показывает «Снять уведомление?»; снятие возвращает исходное состояние. Все 14 карточек устройств на странице деталей — зелёные при живых данных. Бейдж в списке автоматов — обычный колокольчик.

Closes #72
Closes #79
Closes #77