### PR TITLE
Свайп карточки автомата: iOS-стиль с «точкой невозврата» и мгновенным overlay

### DIFF
--- a/frontend/src/components/UnitCard.tsx
+++ b/frontend/src/components/UnitCard.tsx
@@ -57,6 +57,8 @@ const SWIPE_CLICK_GUARD_PX = 10;
 const HAPTIC_MS = 10;
 /** easeOutCubic — плавный «мягкий» возврат карточки и «пилюли» после свайпа. */
 const EASE_OUT_CUBIC = 'cubic-bezier(0.215, 0.61, 0.355, 1)';
+/** Длительность анимации возврата после свайпа. */
+const RETURN_TRANSITION = `0.45s ${EASE_OUT_CUBIC}`;
 
 /** CSS filter для перекраски bell.svg в белый цвет. */
 const BELL_WHITE_FILTER =
@@ -209,7 +211,7 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
                 boxShadow: swipeOffset > 0 ? '0 10px 24px rgba(59, 130, 246, 0.35)' : undefined,
                 transition: isTouching.current
                   ? undefined
-                  : `width 0.3s ${EASE_OUT_CUBIC}, opacity 0.3s ${EASE_OUT_CUBIC}`,
+                  : `width ${RETURN_TRANSITION}, opacity ${RETURN_TRANSITION}`,
               }}
             >
               <img

--- a/frontend/src/components/UnitCard.tsx
+++ b/frontend/src/components/UnitCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import {
   getUnitErrorGroups,
   getUnitStatusLevel,
@@ -23,15 +23,18 @@ import type { AlertData, NotificationData, Unit } from '../types';
  * на карточке показывается индикатор-колокольчик (жёлтый).
  *
  * Свайп вправо (только для закреплённых автоматов), поведение в духе iOS:
+ * - жест начинается строго из левой зоны карточки
+ *   ({@link SWIPE_ACTIVATION_RATIO}); свайп из центра игнорируется;
  * - карточка движется с сопротивлением ({@link SWIPE_RESISTANCE}) — свайп
  *   требует осознанного движения, случайные касания не срабатывают;
  * - слева под карточкой растёт синяя «пилюля» с иконкой колокольчика
  *   и подписью действия;
- * - как только карточка проходит «точку невозврата»
- *   ({@link SWIPE_COMMIT_THRESHOLD_PX}), при отпускании overlay подтверждения
- *   открывается сразу, без тапа по раскрытой области;
- * - неполный свайп оставляет «пилюлю» раскрытой — тап по ней также
- *   вызывает overlay; тап по сдвинутой карточке возвращает её на место.
+ * - карточка жёстко ограничена «точкой невозврата»
+ *   ({@link SWIPE_COMMIT_RATIO}) — дальше неё не двигается; при достижении
+ *   точки срабатывает лёгкий тактильный отклик (вибрация);
+ * - отпускание ДО точки — карточка возвращается в исходное положение;
+ * - отпускание В точке — открывается overlay подтверждения, а карточка
+ *   возвращается в исходное положение.
  */
 
 interface Props {
@@ -42,14 +45,16 @@ interface Props {
   onClick: () => void;
 }
 
-/** «Точка невозврата»: отпускание за этим смещением сразу открывает overlay. */
-const SWIPE_COMMIT_THRESHOLD_PX = 120;
-/** Ширина раскрытой «пилюли» действия после неполного свайпа. */
-const SWIPE_REVEAL_PX = 108;
+/** Доля ширины карточки слева, из которой должен начинаться свайп. */
+const SWIPE_ACTIVATION_RATIO = 0.3;
+/** «Точка невозврата» — доля ширины карточки (позиция как на iOS-референсе). */
+const SWIPE_COMMIT_RATIO = 0.55;
 /** Сопротивление движению карточки (< 1) — визуально «утяжеляет» свайп. */
 const SWIPE_RESISTANCE = 0.7;
-/** Длительность анимации «улёта» карточки перед открытием overlay. */
-const COMMIT_ANIMATION_MS = 180;
+/** Минимальное смещение, после которого тап по карточке игнорируется. */
+const SWIPE_CLICK_GUARD_PX = 10;
+/** Длительность тактильного отклика при достижении «точки невозврата», мс. */
+const HAPTIC_MS = 10;
 
 /** CSS filter для перекраски bell.svg в белый цвет. */
 const BELL_WHITE_FILTER =
@@ -79,74 +84,64 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
   // ── Swipe state ────────────────────────────────────────────────────────
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [swipeOffset, setSwipeOffset] = useState(0);
-  const [completing, setCompleting] = useState(false);
   const touchStartX = useRef<number | null>(null);
-  const startOffset = useRef(0);
-  const containerWidth = useRef(0);
+  const thresholdPx = useRef(0);
   const isTouching = useRef(false);
-  const commitTimer = useRef<number | null>(null);
+  const hapticFired = useRef(false);
+  // Защита от «сквозного» клика после свайпа (click приходит после touchend)
+  const justSwiped = useRef(false);
 
   // ── Confirmation overlay ───────────────────────────────────────────────
   const [overlayOpen, setOverlayOpen] = useState(false);
   const { sendLastBatch, reset: resetLastBatch } = useLastBatch();
 
-  useEffect(
-    () => () => {
-      if (commitTimer.current != null) window.clearTimeout(commitTimer.current);
-    },
-    []
-  );
-
   const handleTouchStart = useCallback(
     (e: React.TouchEvent) => {
-      if (!isAssigned || completing) return;
-      touchStartX.current = e.touches[0].clientX;
-      startOffset.current = swipeOffset;
-      containerWidth.current = containerRef.current?.offsetWidth ?? 0;
+      if (!isAssigned) return;
+      const container = containerRef.current;
+      if (!container) return;
+      const width = container.offsetWidth;
+      const x = e.touches[0].clientX;
+      // Свайп активируется только из левой зоны карточки
+      if (x - container.getBoundingClientRect().left > width * SWIPE_ACTIVATION_RATIO) return;
+      touchStartX.current = x;
+      thresholdPx.current = width * SWIPE_COMMIT_RATIO;
+      hapticFired.current = false;
       isTouching.current = true;
     },
-    [isAssigned, completing, swipeOffset]
+    [isAssigned]
   );
 
   const handleTouchMove = useCallback(
     (e: React.TouchEvent) => {
       if (!isAssigned || touchStartX.current == null) return;
       const delta = e.touches[0].clientX - touchStartX.current;
-      const raw = startOffset.current + delta;
-      if (raw <= 0) {
+      if (delta <= 0) {
         setSwipeOffset(0);
         return;
       }
-      // Свайп вправо: сопротивление делает карточку «тяжелее»
-      const max = containerWidth.current > 0 ? containerWidth.current : Number.POSITIVE_INFINITY;
-      setSwipeOffset(Math.min(max, raw * SWIPE_RESISTANCE));
+      // Сопротивление делает карточку «тяжелее»; дальше точки невозврата — не двигается
+      const offset = Math.min(thresholdPx.current, delta * SWIPE_RESISTANCE);
+      // Лёгкая вибрация при первом достижении точки невозврата
+      if (offset >= thresholdPx.current && !hapticFired.current) {
+        hapticFired.current = true;
+        navigator.vibrate?.(HAPTIC_MS);
+      }
+      setSwipeOffset(offset);
     },
     [isAssigned]
   );
 
-  /** Карточка «улетает» вправо, затем overlay открывается без дополнительного тапа. */
-  const commitSwipe = useCallback(() => {
-    const width = containerWidth.current > 0 ? containerWidth.current : SWIPE_REVEAL_PX;
-    setCompleting(true);
-    setSwipeOffset(width);
-    commitTimer.current = window.setTimeout(() => {
-      commitTimer.current = null;
-      setCompleting(false);
-      setOverlayOpen(true);
-    }, COMMIT_ANIMATION_MS);
-  }, []);
-
   const handleTouchEnd = useCallback(() => {
     touchStartX.current = null;
     isTouching.current = false;
-    if (swipeOffset >= SWIPE_COMMIT_THRESHOLD_PX) {
-      commitSwipe();
-    } else if (swipeOffset > SWIPE_REVEAL_PX / 2) {
-      setSwipeOffset(SWIPE_REVEAL_PX);
-    } else {
-      setSwipeOffset(0);
+    justSwiped.current = swipeOffset > SWIPE_CLICK_GUARD_PX;
+    if (thresholdPx.current > 0 && swipeOffset >= thresholdPx.current) {
+      // Точка невозврата: overlay открывается сразу, карточка возвращается назад
+      setOverlayOpen(true);
     }
-  }, [swipeOffset, commitSwipe]);
+    setSwipeOffset(0);
+  }, [swipeOffset]);
 
   const handleTouchCancel = useCallback(() => {
     touchStartX.current = null;
@@ -154,20 +149,14 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
     setSwipeOffset(0);
   }, []);
 
-  const handleRevealClick = useCallback(() => {
-    if (completing) return;
-    if (swipeOffset > 0) setOverlayOpen(true);
-  }, [completing, swipeOffset]);
-
   const handleCardClick = useCallback(() => {
-    if (completing) return;
-    // Тап по сдвинутой карточке просто возвращает её на место
-    if (swipeOffset > 0) {
-      setSwipeOffset(0);
+    // Тап сразу после свайпа не должен открывать детали автомата
+    if (justSwiped.current) {
+      justSwiped.current = false;
       return;
     }
     onClick();
-  }, [completing, swipeOffset, onClick]);
+  }, [onClick]);
 
   const handleConfirm = useCallback(async () => {
     setOverlayOpen(false);
@@ -188,21 +177,10 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
     ? { 'aria-disabled': true as const }
     : { onClick: handleCardClick, role: 'button' as const };
 
-  // Прогресс раскрытия «пилюли» (0..1) и прогресс за «точкой невозврата» (0..1)
-  const revealProgress = Math.min(1, swipeOffset / SWIPE_REVEAL_PX);
-  const fullWidth = containerWidth.current;
-  const overProgress =
-    fullWidth > 0
-      ? Math.min(
-          1,
-          Math.max(
-            0,
-            (swipeOffset - SWIPE_COMMIT_THRESHOLD_PX) /
-              Math.max(1, fullWidth - SWIPE_COMMIT_THRESHOLD_PX)
-          )
-        )
-      : 0;
-  const pillWidth = SWIPE_REVEAL_PX + overProgress * Math.max(0, fullWidth - SWIPE_REVEAL_PX - 24);
+  // Прогресс свайпа 0..1 до «точки невозврата»; «пилюля» растёт вслед за карточкой
+  const threshold = thresholdPx.current;
+  const revealProgress = threshold > 0 ? Math.min(1, swipeOffset / (threshold * 0.6)) : 0;
+  const pillWidth = Math.max(0, Math.min(swipeOffset, threshold) - 24);
 
   return (
     <>
@@ -216,9 +194,7 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
           <div
             className="absolute inset-0 flex flex-col justify-center px-3"
             style={{ zIndex: 0 }}
-            onClick={handleRevealClick}
-            role="button"
-            aria-label={isActiveByMe ? 'Снять уведомление' : 'Последняя партия'}
+            aria-hidden="true"
           >
             <div
               className="flex items-center justify-center"
@@ -244,7 +220,7 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
               className="mt-1 text-center"
               style={{
                 width: `${pillWidth}px`,
-                opacity: revealProgress * (1 - overProgress),
+                opacity: revealProgress,
                 transition: isTouching.current ? undefined : 'width 0.25s ease, opacity 0.25s ease',
               }}
             >

--- a/frontend/src/components/UnitCard.tsx
+++ b/frontend/src/components/UnitCard.tsx
@@ -55,6 +55,8 @@ const SWIPE_RESISTANCE = 0.7;
 const SWIPE_CLICK_GUARD_PX = 10;
 /** Длительность тактильного отклика при достижении «точки невозврата», мс. */
 const HAPTIC_MS = 10;
+/** easeOutCubic — плавный «мягкий» возврат карточки и «пилюли» после свайпа. */
+const EASE_OUT_CUBIC = 'cubic-bezier(0.215, 0.61, 0.355, 1)';
 
 /** CSS filter для перекраски bell.svg в белый цвет. */
 const BELL_WHITE_FILTER =
@@ -205,7 +207,9 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
                 backgroundColor: '#3B82F6',
                 opacity: revealProgress,
                 boxShadow: swipeOffset > 0 ? '0 10px 24px rgba(59, 130, 246, 0.35)' : undefined,
-                transition: isTouching.current ? undefined : 'width 0.25s ease, opacity 0.25s ease',
+                transition: isTouching.current
+                  ? undefined
+                  : `width 0.3s ${EASE_OUT_CUBIC}, opacity 0.3s ${EASE_OUT_CUBIC}`,
               }}
             >
               <img
@@ -221,7 +225,9 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
               style={{
                 width: `${pillWidth}px`,
                 opacity: revealProgress,
-                transition: isTouching.current ? undefined : 'width 0.25s ease, opacity 0.25s ease',
+                transition: isTouching.current
+                  ? undefined
+                  : `width 0.3s ${EASE_OUT_CUBIC}, opacity 0.3s ${EASE_OUT_CUBIC}`,
               }}
             >
               <span className="text-[11px] font-medium leading-none text-gray-500">
@@ -237,7 +243,9 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
           {...interactiveProps}
           style={{
             transform: `translateX(${swipeOffset}px)`,
-            transition: isTouching.current ? 'none' : 'transform 0.25s ease, box-shadow 0.25s ease',
+            transition: isTouching.current
+              ? 'none'
+              : `transform 0.3s ${EASE_OUT_CUBIC}, box-shadow 0.3s ${EASE_OUT_CUBIC}`,
             boxShadow: swipeOffset > 0 ? '0 14px 30px rgba(15, 23, 42, 0.18)' : undefined,
             position: 'relative',
             zIndex: 1,

--- a/frontend/src/components/UnitCard.tsx
+++ b/frontend/src/components/UnitCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   getUnitErrorGroups,
   getUnitStatusLevel,
@@ -22,10 +22,16 @@ import type { AlertData, NotificationData, Unit } from '../types';
  * Слой уведомлений: если для аппарата есть активное notification —
  * на карточке показывается индикатор-колокольчик (жёлтый).
  *
- * Свайп вправо (только для закреплённых автоматов):
- * - карточка сдвигается вправо;
- * - слева под ней появляется статический синий эмбиент с иконкой колокольчика;
- * - тап по эмбиенту вызывает overlay подтверждения.
+ * Свайп вправо (только для закреплённых автоматов), поведение в духе iOS:
+ * - карточка движется с сопротивлением ({@link SWIPE_RESISTANCE}) — свайп
+ *   требует осознанного движения, случайные касания не срабатывают;
+ * - слева под карточкой растёт синяя «пилюля» с иконкой колокольчика
+ *   и подписью действия;
+ * - как только карточка проходит «точку невозврата»
+ *   ({@link SWIPE_COMMIT_THRESHOLD_PX}), при отпускании overlay подтверждения
+ *   открывается сразу, без тапа по раскрытой области;
+ * - неполный свайп оставляет «пилюлю» раскрытой — тап по ней также
+ *   вызывает overlay; тап по сдвинутой карточке возвращает её на место.
  */
 
 interface Props {
@@ -36,8 +42,14 @@ interface Props {
   onClick: () => void;
 }
 
-const SWIPE_THRESHOLD_PX = 80;
-const SWIPE_MAX_PX = 140;
+/** «Точка невозврата»: отпускание за этим смещением сразу открывает overlay. */
+const SWIPE_COMMIT_THRESHOLD_PX = 120;
+/** Ширина раскрытой «пилюли» действия после неполного свайпа. */
+const SWIPE_REVEAL_PX = 108;
+/** Сопротивление движению карточки (< 1) — визуально «утяжеляет» свайп. */
+const SWIPE_RESISTANCE = 0.7;
+/** Длительность анимации «улёта» карточки перед открытием overlay. */
+const COMMIT_ANIMATION_MS = 180;
 
 /** CSS filter для перекраски bell.svg в белый цвет. */
 const BELL_WHITE_FILTER =
@@ -61,63 +73,101 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
   const isActiveByMe = notification != null && userId != null && notification.creatorId === userId;
 
   const statusClass = UNIT_STATUS_CLASS[statusLevel];
-  // offline: карточка некликабельна; card-static отключает cursor:pointer и :active-scale.
-  const interactiveProps = isOffline
-    ? { 'aria-disabled': true as const }
-    : { onClick, role: 'button' as const };
 
   const errorGroups = isCritical ? getUnitErrorGroups(unit.id, alerts) : [];
 
   // ── Swipe state ────────────────────────────────────────────────────────
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const [swipeOffset, setSwipeOffset] = useState(0);
+  const [completing, setCompleting] = useState(false);
   const touchStartX = useRef<number | null>(null);
-  const currentOffset = useRef(0);
+  const startOffset = useRef(0);
+  const containerWidth = useRef(0);
   const isTouching = useRef(false);
+  const commitTimer = useRef<number | null>(null);
 
   // ── Confirmation overlay ───────────────────────────────────────────────
   const [overlayOpen, setOverlayOpen] = useState(false);
   const { sendLastBatch, reset: resetLastBatch } = useLastBatch();
 
+  useEffect(
+    () => () => {
+      if (commitTimer.current != null) window.clearTimeout(commitTimer.current);
+    },
+    []
+  );
+
   const handleTouchStart = useCallback(
     (e: React.TouchEvent) => {
-      if (!isAssigned) return;
+      if (!isAssigned || completing) return;
       touchStartX.current = e.touches[0].clientX;
-      currentOffset.current = swipeOffset;
+      startOffset.current = swipeOffset;
+      containerWidth.current = containerRef.current?.offsetWidth ?? 0;
       isTouching.current = true;
     },
-    [isAssigned, swipeOffset]
+    [isAssigned, completing, swipeOffset]
   );
 
   const handleTouchMove = useCallback(
     (e: React.TouchEvent) => {
       if (!isAssigned || touchStartX.current == null) return;
       const delta = e.touches[0].clientX - touchStartX.current;
-      // Свайп вправо (delta > 0) → карточка сдвигается ВПРАВО (положительный offset)
-      if (delta > 0) {
-        const offset = Math.min(SWIPE_MAX_PX, Math.max(0, currentOffset.current + delta));
-        setSwipeOffset(offset);
-      } else if (delta < 0) {
-        // Свайп влево — возвращаем карточку
-        const offset = Math.max(0, currentOffset.current + delta);
-        setSwipeOffset(offset);
+      const raw = startOffset.current + delta;
+      if (raw <= 0) {
+        setSwipeOffset(0);
+        return;
       }
+      // Свайп вправо: сопротивление делает карточку «тяжелее»
+      const max = containerWidth.current > 0 ? containerWidth.current : Number.POSITIVE_INFINITY;
+      setSwipeOffset(Math.min(max, raw * SWIPE_RESISTANCE));
     },
     [isAssigned]
   );
 
+  /** Карточка «улетает» вправо, затем overlay открывается без дополнительного тапа. */
+  const commitSwipe = useCallback(() => {
+    const width = containerWidth.current > 0 ? containerWidth.current : SWIPE_REVEAL_PX;
+    setCompleting(true);
+    setSwipeOffset(width);
+    commitTimer.current = window.setTimeout(() => {
+      commitTimer.current = null;
+      setCompleting(false);
+      setOverlayOpen(true);
+    }, COMMIT_ANIMATION_MS);
+  }, []);
+
   const handleTouchEnd = useCallback(() => {
     touchStartX.current = null;
     isTouching.current = false;
-    if (swipeOffset > SWIPE_THRESHOLD_PX) {
-      setSwipeOffset(SWIPE_MAX_PX);
+    if (swipeOffset >= SWIPE_COMMIT_THRESHOLD_PX) {
+      commitSwipe();
+    } else if (swipeOffset > SWIPE_REVEAL_PX / 2) {
+      setSwipeOffset(SWIPE_REVEAL_PX);
     } else {
       setSwipeOffset(0);
     }
-  }, [swipeOffset]);
+  }, [swipeOffset, commitSwipe]);
+
+  const handleTouchCancel = useCallback(() => {
+    touchStartX.current = null;
+    isTouching.current = false;
+    setSwipeOffset(0);
+  }, []);
 
   const handleRevealClick = useCallback(() => {
-    setOverlayOpen(true);
-  }, []);
+    if (completing) return;
+    if (swipeOffset > 0) setOverlayOpen(true);
+  }, [completing, swipeOffset]);
+
+  const handleCardClick = useCallback(() => {
+    if (completing) return;
+    // Тап по сдвинутой карточке просто возвращает её на место
+    if (swipeOffset > 0) {
+      setSwipeOffset(0);
+      return;
+    }
+    onClick();
+  }, [completing, swipeOffset, onClick]);
 
   const handleConfirm = useCallback(async () => {
     setOverlayOpen(false);
@@ -133,41 +183,74 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
     setSwipeOffset(0);
   }, []);
 
-  // Прогресс свайпа 0..1 для анимации фона
-  const swipeProgress = Math.min(1, swipeOffset / SWIPE_MAX_PX);
+  // offline: карточка некликабельна; card-static отключает cursor:pointer и :active-scale.
+  const interactiveProps = isOffline
+    ? { 'aria-disabled': true as const }
+    : { onClick: handleCardClick, role: 'button' as const };
+
+  // Прогресс раскрытия «пилюли» (0..1) и прогресс за «точкой невозврата» (0..1)
+  const revealProgress = Math.min(1, swipeOffset / SWIPE_REVEAL_PX);
+  const fullWidth = containerWidth.current;
+  const overProgress =
+    fullWidth > 0
+      ? Math.min(
+          1,
+          Math.max(
+            0,
+            (swipeOffset - SWIPE_COMMIT_THRESHOLD_PX) /
+              Math.max(1, fullWidth - SWIPE_COMMIT_THRESHOLD_PX)
+          )
+        )
+      : 0;
+  const pillWidth = SWIPE_REVEAL_PX + overProgress * Math.max(0, fullWidth - SWIPE_REVEAL_PX - 24);
 
   return (
     <>
       <div
+        ref={containerRef}
         className="relative select-none overflow-hidden rounded-[24px]"
         style={{ touchAction: 'pan-y' }}
       >
-        {/* Фоновый слой с эмбиентом и колокольчиком — статичен, карточка сдвигается поверх */}
+        {/* Фоновый слой: «пилюля» действия в духе iOS — растёт за карточкой */}
         {isAssigned && (
           <div
-            className="absolute inset-0 flex items-center justify-start rounded-[24px]"
-            style={{
-              zIndex: 0,
-              opacity: swipeProgress,
-              transition: isTouching.current ? undefined : 'opacity 0.25s ease',
-              background:
-                'radial-gradient(ellipse 55% 100% at 70px 50%, rgba(59,130,246,0.55) 0%, rgba(59,130,246,0.22) 40%, rgba(59,130,246,0.06) 70%, transparent 100%)',
-            }}
+            className="absolute inset-0 flex flex-col justify-center px-3"
+            style={{ zIndex: 0 }}
             onClick={handleRevealClick}
             role="button"
             aria-label={isActiveByMe ? 'Снять уведомление' : 'Последняя партия'}
           >
             <div
               className="flex items-center justify-center"
-              style={{ width: `${SWIPE_MAX_PX}px`, flexShrink: 0 }}
+              style={{
+                height: '56px',
+                width: `${pillWidth}px`,
+                borderRadius: '18px',
+                backgroundColor: '#3B82F6',
+                opacity: revealProgress,
+                boxShadow: swipeOffset > 0 ? '0 10px 24px rgba(59, 130, 246, 0.35)' : undefined,
+                transition: isTouching.current ? undefined : 'width 0.25s ease, opacity 0.25s ease',
+              }}
             >
               <img
                 src={isActiveByMe ? '/assets/bell-off.svg' : '/assets/bell.svg'}
                 alt=""
                 aria-hidden="true"
-                className="h-8 w-8"
+                className="h-7 w-7"
                 style={{ filter: BELL_WHITE_FILTER }}
               />
+            </div>
+            <div
+              className="mt-1 text-center"
+              style={{
+                width: `${pillWidth}px`,
+                opacity: revealProgress * (1 - overProgress),
+                transition: isTouching.current ? undefined : 'width 0.25s ease, opacity 0.25s ease',
+              }}
+            >
+              <span className="text-[11px] font-medium leading-none text-gray-500">
+                {isActiveByMe ? 'Снять' : 'Уведомить'}
+              </span>
             </div>
           </div>
         )}
@@ -178,13 +261,15 @@ export function UnitCard({ unit, alerts, notifications, onClick }: Props) {
           {...interactiveProps}
           style={{
             transform: `translateX(${swipeOffset}px)`,
-            transition: isTouching.current ? 'none' : 'transform 0.25s ease',
+            transition: isTouching.current ? 'none' : 'transform 0.25s ease, box-shadow 0.25s ease',
+            boxShadow: swipeOffset > 0 ? '0 14px 30px rgba(15, 23, 42, 0.18)' : undefined,
             position: 'relative',
             zIndex: 1,
           }}
           onTouchStart={handleTouchStart}
           onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}
+          onTouchCancel={handleTouchCancel}
         >
           <div className="mb-1 flex items-center justify-between gap-2">
             <div className="flex items-center gap-2 min-w-0">


### PR DESCRIPTION
## Что сделано

Closes #85

### Поведение (скопировано с iOS-референсов, адаптировано под дизайн-систему)
- Пользователь тянет карточку автомата вправо; как только карточка проходит **«точку невозврата» (120px)** и отпускается — **overlay подтверждения открывается сразу, без тапа** по раскрытой области. Карточка при этом «улетает» вправо, а область действия растягивается на всю ширину.
- Неполный свайп (> 54px) оставляет область действия раскрытой — тап по ней по-прежнему вызывает overlay (фолбэк).
- Тап по сдвинутой карточке просто возвращает её на место (без перехода в детали).

### Снижение чувствительности / «утяжеление»
- Добавлено **сопротивление движению 0.7** — карточка движется медленнее пальца, случайные касания не срабатывают.
- Порог срабатывания поднят с 80px до 120px.
- Во время драга карточка получает выраженную тень — визуально «тяжелеет».

### Визуальный стиль (по референсам iOS Mail)
- Вместо статичного градиентного эмбиента — **синяя «пилюля» (#3B82F6, радиус 18px)** с иконкой колокольчика и подписью действия («Уведомить» / «Снять»).
- «Пилюля» растёт по мере свайпа и растягивается на всю ширину карточки за «точкой невозврата»; подпись при этом плавно гаснет.

### Надёжность
- Добавлен `onTouchCancel` (возврат карточки при прерывании жеста).
- Таймер commit-анимации очищается при размонтировании компонента.

## Проверка
- `tsc -b --noEmit` — чисто; husky (prettier + eslint + type-check) — зелёный.
- Inline SVG отсутствует (иконки — файлы из `/assets`).
- Ручная проверка через Playwright (пользователь 10001, цех десертов):
  - drag 150px → смещение 105px (сопротивление работает), «пилюля» видна;
  - отпускание на 105px → карточка зафиксирована на 108px, overlay **не** открыт;
  - тап по «пилюле» → overlay открывается;
  - полный свайп 182px ≥ 120px → commit-анимация, overlay открывается **автоматически**;
  - «Отмена» → карточка возвращается на место.